### PR TITLE
Fix Markdown syntax

### DIFF
--- a/docs/overview/value_classes.md
+++ b/docs/overview/value_classes.md
@@ -11,6 +11,6 @@ value class Pair(x: Int, y: Int)
 
 When creating a `Vector<Pair>`, both the fields of the object are going to be flattened. The upside is that it saves an allocation and that it makes accessing the field of an element in the Vector faster (it avoids an extra indirection). The downside is that moving a Pair out of the Vector requires a copy.
 
-**Note: ***value classes cannot define mutable fields, which is why the difference with a normal class cannot be observed at runtime.*
+**Note:** *value classes cannot define mutable fields, which is why the difference with a normal class cannot be observed at runtime.*
 
 **Note2:** *value classes cannot extend a a base class.*


### PR DESCRIPTION
The `**` `*` need to be separated by space in order to make the Markdown parser recognize „bold end“ and „italic start“ separatedly.