### PR TITLE
[stdlib] Make read_stdin untracked

### DIFF
--- a/src/nuclide/outline.sk
+++ b/src/nuclide/outline.sk
@@ -277,7 +277,7 @@ fun processFile(fileName: String): void {
   outline(FileSystem.readTextFile(fileName))
 }
 
-fun main(): void {
+untracked fun main(): void {
   args = arguments();
   if (args.isEmpty()) {
     outline(read_stdin());

--- a/src/nuclide/skipFormat.sk
+++ b/src/nuclide/skipFormat.sk
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-fun main(): void {
+untracked fun main(): void {
   contents = read_stdin();
   parsed = SkipParser.parseSource(contents, false);
 

--- a/src/runtime/prelude/stdlib/other/System.sk
+++ b/src/runtime/prelude/stdlib/other/System.sk
@@ -228,7 +228,7 @@ native fun getBuildVersion(): String;
 
 @cpp_runtime
 @may_alloc
-native fun read_stdin(): String;
+untracked native fun read_stdin(): String;
 
 @cpp_runtime
 @may_alloc

--- a/src/tools/CodeModMain.sk
+++ b/src/tools/CodeModMain.sk
@@ -69,7 +69,7 @@ fun transformFileInPlace(filename: String, transFn: String -> String): void {
 
 // Modding a dir in place becomes:
 //    find dir -name '*.sk' | xargs skip_codemod --write
-fun main(): void {
+untracked fun main(): void {
   args = AP.parse(schema, arguments()) match {
   | Success(results) ->
     if (!results.rest.isEmpty()) {

--- a/src/tools/SerializationGenerator.sk
+++ b/src/tools/SerializationGenerator.sk
@@ -11,7 +11,7 @@
 
 module alias PT = ParseTree;
 
-fun main(): void {
+untracked fun main(): void {
   args = arguments();
   source = args.size() match {
   | 0 -> read_stdin()

--- a/src/tools/printerMain.sk
+++ b/src/tools/printerMain.sk
@@ -52,7 +52,7 @@ fun printToStdoutAndReportErrors(contents: String, filename: String): void {
   }
 }
 
-fun main(): void {
+untracked fun main(): void {
   errorMessage = "Usage: skip_printer [--write] [--list-different] <list_of_sk_files>\n";
   initialArgs = PrinterArguments{
     files => Vector[],

--- a/src/tools/skipDocgen.sk
+++ b/src/tools/skipDocgen.sk
@@ -68,7 +68,11 @@ fun getCommentOfPosition(
 }
 
 fun notCopyrightLicenseHeader(comment: Token.Comment): Bool {
-  !comment.value.matches(Regex::create("\\/\\*\\*\\s*\\n\\s*\\*\\s*Copyright\\s+\\(c\\)\\s+Facebook"));
+  !comment.value.matches(
+    Regex::create(
+      "\\/\\*\\*\\s*\\n\\s*\\*\\s*Copyright\\s+\\(c\\)\\s+Facebook",
+    ),
+  );
 }
 
 class Arguments{

--- a/tests/runtime/prelude/stdlib/other/System.sk
+++ b/tests/runtime/prelude/stdlib/other/System.sk
@@ -228,7 +228,7 @@ native fun getBuildVersion(): String;
 
 @cpp_runtime
 @may_alloc
-native fun read_stdin(): String;
+untracked native fun read_stdin(): String;
 
 @cpp_runtime
 @may_alloc


### PR DESCRIPTION
Annotates `read_stdin()` as `untracked` and updates call sites accordingly. It's primarily used directly in `main()` functions, so this change doesn't end up requiring touching too much code.