### PR TITLE
Grammar fix

### DIFF
--- a/docs/overview/variance.md
+++ b/docs/overview/variance.md
@@ -17,7 +17,7 @@ class MyCollection<+T>(value: T) {
 }
 ```
 
-Note that the compiler might refuse the annotation if `T` appears is so-called `contra-variant` position within the definition of the class. As stated earlier, I won't go in the details of what that means here, just rework the API when the compiler is complaining.
+Note that the compiler might refuse the annotation if `T` appears in a so-called `contra-variant` position within the definition of the class. As stated earlier, I won't go in the details of what that means here, just rework the API when the compiler is complaining.
 
 ## Contra-variance
 


### PR DESCRIPTION
I hope I've interpreted the sentence correctly.

An alternative would be:

> Note that the compiler might refuse the annotation if `T` appears in so-called `contra-variant` positions within the definition of the class.

Note the plural of „position“, although I don't know whether there can be many of such positions :)

I can correct it if you want.