### PR TITLE
 Added more complete instructions for building on Arch

### DIFF
--- a/docs/developer/README-cmake.md
+++ b/docs/developer/README-cmake.md
@@ -35,7 +35,37 @@
 
 
 ### Arch Linux
-    pacman -S base-devel git cmake ninja nodejs clang boost libevent google-glog
+Install packages
+
+```
+pacman -S base-devel git cmake python2 ninja nodejs clang boost libevent google-
+glog
+```
+
+Set `python` to default to Python 2
+
+```
+ln -s /usr/bin/python2 $SOME_DIR/python
+export PATH=$SOME_DIR/python:$PATH
+```
+
+Disable warnings as errors by running `git apply` on the following patch
+
+```patch
+diff --git a/CMake/SkipCompiler.cmake b/CMake/SkipCompiler.cmake
+index c8ab080..f61d73c 100644
+--- a/CMake/SkipCompiler.cmake
++++ b/CMake/SkipCompiler.cmake
+@@ -52,7 +52,6 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR
+     $<$<CONFIG:Debug>:-g>
+     $<$<CONFIG:Release>:-DNDEBUG>
+     -Wall
+-    -Werror
+     -msse4.2
+     -Wno-sign-compare
+     )
+
+```
 
 ### OS X
 

--- a/docs/developer/README-cmake.md
+++ b/docs/developer/README-cmake.md
@@ -38,8 +38,7 @@
 Install packages
 
 ```
-pacman -S base-devel git cmake python2 ninja nodejs clang boost libevent google-
-glog
+pacman -S base-devel git cmake python2 ninja nodejs clang boost libevent google-glog
 ```
 
 Set `python` to default to Python 2

--- a/docs/developer/README-cmake.md
+++ b/docs/developer/README-cmake.md
@@ -5,6 +5,7 @@
 1. [Prerequisites](#install-prerequisites)
     1. [Centos](#fb-centos-facebook-only)
     1. [Ubuntu 14.04](#ubuntu-1404)
+    1. [Arch Linux](#arch-linux)
     1. [OS X](#os-x)
 1. [Configure And Build](#configure-and-build-the-repo)
 1. [Adding New Source Files](#adding-new-source-files-or-targets)


### PR DESCRIPTION
Some explanation:

* Arch Linux has `/usr/bin/python` symlinked to Python 3 by default, whereas the build scripts assume Python 2. Ideally we would have all scripts explicitly specify `#!/usr/bin/env python2`, but that may require changing upstream libraries.

* With `-Werror` the build will fail due to the use of `std::memcpy` in the `folly` library to copy (certain) classes. This is possibly due to Arch using a more recent version of either gcc or clang. (I tried setting `CC=gcc-6` to no avail.)