### PR TITLE
Faster compilation time (especially for small programs)

### DIFF
--- a/src/runtime/tools/run
+++ b/src/runtime/tools/run
@@ -42,6 +42,10 @@ def main(stack):
 
     if args.backend == 'native':
         common.buildNinjaTarget('skip_to_native')
+        sk_standalone_o = os.path.join(build_dir,
+           "src/runtime/native/CMakeFiles/sk_standalone.src.dir/src/sk_standalone.cpp.o")
+        if(os.path.exists(sk_standalone_o)):
+            args.sk_standalone = sk_standalone_o
         binFile = skip_native_compile.compile(stack, args)
         cmd = (binFile.name,)
         if args.watch:

--- a/tests/runtime/tools/run
+++ b/tests/runtime/tools/run
@@ -42,6 +42,10 @@ def main(stack):
 
     if args.backend == 'native':
         common.buildNinjaTarget('skip_to_native')
+        sk_standalone_o = os.path.join(build_dir,
+           "src/runtime/native/CMakeFiles/sk_standalone.src.dir/src/sk_standalone.cpp.o")
+        if(os.path.exists(sk_standalone_o)):
+            args.sk_standalone = sk_standalone_o
         binFile = skip_native_compile.compile(stack, args)
         cmd = (binFile.name,)
         if args.watch:


### PR DESCRIPTION
The last step of the compilation consists in building the binary.
The problem is that last step rebuilds every time from source the file sk_standalone.
Because it includes headers from C++ libraries, compiling that file actually takes quite a bit of time.
So I changed the script to use the .o if it is there.

That bring the compilation time for a small program (like hello world) down from 10s to 5s on my machine.