### PR TITLE
Fix duplicate submodules in .gitmodules.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,3 @@
-[submodule "third-party/jemalloc"]
-	path = third-party/jemalloc/src
-	url = https://github.com/jemalloc/jemalloc.git
-[submodule "third-party/googletest"]
-	path = third-party/googletest/src
-	url = https://github.com/google/googletest.git
 [submodule "third-party/double_conversion/src"]
 	path = third-party/double_conversion/src
 	url = https://github.com/google/double-conversion


### PR DESCRIPTION
Currently there are duplicate entries for `jemalloc` and `googletest` in the `.gitmodules` file for this repo. While `git` itself has no issue with this, other implementations of git do.

This PR removes the duplicate entries to allow the repository to work properly with other git implementations while ensuring that it still builds. 