### PR TITLE
[Refactor] Simplify the React.Component

### DIFF
--- a/website/playground/static/playground.js
+++ b/website/playground/static/playground.js
@@ -185,9 +185,8 @@ window.setupEditor = function(elements, options = {}, basePath = '', hiddenCode 
     class Node extends React.Component {
       constructor(props) {
         super(props);
-        this.toggle = this.toggle.bind(this);
       }
-      toggle() {
+      toggle = () => {
         this.props.node.__isToggled = !this.props.node.__isToggled;
         this.forceUpdate();
       }

--- a/website/playground/static/playground.js
+++ b/website/playground/static/playground.js
@@ -183,9 +183,6 @@ window.setupEditor = function(elements, options = {}, basePath = '', hiddenCode 
     var marks = [];
     var scrollTo = false;
     class Node extends React.Component {
-      constructor(props) {
-        super(props);
-      }
       toggle = () => {
         this.props.node.__isToggled = !this.props.node.__isToggled;
         this.forceUpdate();


### PR DESCRIPTION
Using arrow function to bind the context rather than use .bind() function
Remove constructor (which has no side effect )