### PR TITLE
Speedup of the  string literal lexer

### DIFF
--- a/src/frontend/skipToken.sk
+++ b/src/frontend/skipToken.sk
@@ -9,11 +9,11 @@ module Token;
 
 extension class Token{} {
   fun stringLiteralValue(): String {
-    accumulateStringValue("", this.value.sub(1, this.value.length() - 2), 0)
+    stringValue(this.value.sub(1, this.value.length() - 2))
   }
 
   fun templateStringLiteralValue(): String {
-    accumulateStringValue("", this.value, 0)
+    stringValue(this.value)
   }
 
   fun charLiteralValue(): Char {
@@ -103,19 +103,6 @@ fun charLiteral(value: String): Char {
   Char::fromCode(charLiteralCode(value))
 }
 
-fun charLiteralLength(value: String, index: Int): Int {
-  if (value[index] != '\\') {
-    1
-  } else {
-    value[index + 1] match {
-    | 'x' -> 4
-    | 'u' -> 6
-    | 'U' -> 10
-    | _ -> 2
-    }
-  }
-}
-
 // Note this does not include quotes around the result.
 fun escapeCharLiteralValue(ch: Char): String {
   ch match {
@@ -151,15 +138,29 @@ fun escapeStringLiteralValue(s: String): String {
   s.chars().map(escapeCharLiteralValue).join("")
 }
 
-fun accumulateStringValue(acc: String, value: String, index: Int): String {
-  if (index == value.length()) {
-    acc
-  } else {
-    length = charLiteralLength(value, index);
-    accumulateStringValue(
-      acc + charLiteral(value.sub(index, length)),
-      value,
-      index + length,
-    )
-  }
+fun stringValue(value: String): String {
+  chars = value.chars();
+  acc = mutable Vector[];
+  i = 0;
+  while (i < chars.size()) {
+    literal = mutable Vector[];
+    literalSize = chars[i] match {
+    | '\\' ->
+      chars[i + 1] match {
+      | 'x' -> 4
+      | 'u' -> 6
+      | 'U' -> 10
+      | _ -> 2
+      }
+    | _ -> 1
+    };
+    for (j in Range(0, literalSize)) {
+      if (i + j < chars.size()) {
+        literal.push(chars[i + j])
+      }
+    };
+    !i = i + literalSize;
+    acc.push(charLiteral(String::fromChars(freeze(literal).toArray())))
+  };
+  String::fromChars(freeze(acc).toArray())
 }

--- a/src/runtime/prelude/core/primitives/String.sk
+++ b/src/runtime/prelude/core/primitives/String.sk
@@ -14,6 +14,8 @@ native class .String uses Hashable, Show, Orderable {
   @cpp_runtime
   @may_alloc
   native static fun fromUtf8(bytes: readonly Array<UInt8>): String;
+
+  // Careful, this is O(n) (because of utf8)
   @cpp_runtime
   native private fun unsafe_get(x: Int): Char;
 
@@ -35,8 +37,13 @@ native class .String uses Hashable, Show, Orderable {
         throwOutOfBounds()
       };
 
-      v = Array::fillBy(len, i -> this.unsafe_get(start + i));
-      static::fromChars(v)
+      // We don't want to use unsafe_get because it is O(n)
+      subString = mutable Vector[];
+      iter = this.getIter().drop(start);
+      for (_ in Range(0, len)) {
+        subString.push(iter.next().fromSome())
+      };
+      static::fromChars(freeze(subString.toArray()))
     }
   }
 

--- a/tests/runtime/prelude/core/primitives/String.sk
+++ b/tests/runtime/prelude/core/primitives/String.sk
@@ -14,6 +14,8 @@ native class .String uses Hashable, Show, Orderable {
   @cpp_runtime
   @may_alloc
   native static fun fromUtf8(bytes: readonly Array<UInt8>): String;
+
+  // Careful, this is O(n) (because of utf8)
   @cpp_runtime
   native private fun unsafe_get(x: Int): Char;
 
@@ -35,8 +37,13 @@ native class .String uses Hashable, Show, Orderable {
         throwOutOfBounds()
       };
 
-      v = Array::fillBy(len, i -> this.unsafe_get(start + i));
-      static::fromChars(v)
+      // We don't want to use unsafe_get because it is O(n)
+      subString = mutable Vector[];
+      iter = this.getIter().drop(start);
+      for (_ in Range(0, len)) {
+        subString.push(iter.next().fromSome())
+      };
+      static::fromChars(freeze(subString.toArray()))
     }
   }
 


### PR DESCRIPTION
Loading a file with large strings was taking a long time because
the implementation of substring was not very efficient (it was
using unsafe_get, which is O(n) on utf8 strings).

Also, the special character decoding made many calls to substring,
which is O(n) (again because of ut8).