### PR TITLE
Removed unused field.

### DIFF
--- a/src/frontend/skipTypedAst.sk
+++ b/src/frontend/skipTypedAst.sk
@@ -23,7 +23,6 @@ class Program{
   class_defs: UMap<Class_def>,
   fun_defs: UMap<Fun_def>,
   const_defs: UMap<Const_def>,
-  tya_defs: UMap<Type_alias_def>,
 }
 
 class Const_def{

--- a/src/frontend/skipTyping.sk
+++ b/src/frontend/skipTyping.sk
@@ -236,7 +236,6 @@ fun program(prog: SkipAst.Program): SkipTypedAst.Program {
   for (ta in prog.type_defs) {
     SkipNaming.check_type_alias(ta)
   };
-  tya_defs = prog.type_defs.map((_, ta) -> SkipNaming.type_alias(ta));
   defs = programToDefinitions(prog.class_defs, prog.const_defs, prog.fun_defs);
   defsOrErrors = defs.parallelMap(def ~> {
     SkipError.doWithError(() -> {
@@ -283,7 +282,7 @@ fun program(prog: SkipAst.Program): SkipTypedAst.Program {
   });
 
   if (errors.size() == 0) {
-    TAst.Program{fun_defs, const_defs, class_defs, tya_defs}
+    TAst.Program{fun_defs, const_defs, class_defs}
   } else {
     throw SkipError.SkipErrorException{errors => freeze(errors).flatten()}
   }

--- a/src/outer/outerIst.sk
+++ b/src/outer/outerIst.sk
@@ -47,7 +47,6 @@ class Program{
   class_defs: UMap<ClassDef>,
   fun_defs: UMap<FunDef>,
   const_defs: UMap<ConstDef>,
-  tya_defs: UMap<TypeAliasDef>,
 }
 
 class TypeAliasDef{

--- a/src/outer/skipMakeOuterIst.sk
+++ b/src/outer/skipMakeOuterIst.sk
@@ -61,8 +61,7 @@ fun program_phase(prog: TAst.Program): O.Program {
   const_defs = prog.const_defs.map(const_def);
   class_defs = prog.class_defs.map(class_def);
   fun_defs = prog.fun_defs.map(fun_def);
-  tya_defs = prog.tya_defs.map(tya_def);
-  O.Program{const_defs, class_defs, fun_defs, tya_defs}
+  O.Program{const_defs, class_defs, fun_defs}
 }
 
 fun program(prog: TAst.Program): O.Program {

--- a/src/outer/skipOuterIstUtils.sk
+++ b/src/outer/skipOuterIstUtils.sk
@@ -900,14 +900,12 @@ fun map_program(
   map_class_def: O.ClassDef -> O.ClassDef,
   map_const_def: O.ConstDef -> O.ConstDef,
   map_fun_def: O.FunDef -> O.FunDef,
-  map_type_alias_def: O.TypeAliasDef -> O.TypeAliasDef,
   prog: O.Program,
 ): O.Program {
   O.Program{
     class_defs => prog.class_defs.map((_, x) -> map_class_def(x)),
     const_defs => prog.const_defs.map((_, x) -> map_const_def(x)),
     fun_defs => prog.fun_defs.map((_, x) -> map_fun_def(x)),
-    tya_defs => prog.tya_defs.map((_, x) -> map_type_alias_def(x)),
   }
 }
 
@@ -1226,7 +1224,6 @@ fun map_program_stmts(
     p -> stmt_map_to_class_map(map_stmt, p),
     p -> stmt_map_to_const_map(map_stmt, p),
     p -> stmt_map_to_fun_map(map_stmt, p),
-    id,
     prog,
   )
 }

--- a/src/outer/skipRenameLocals.sk
+++ b/src/outer/skipRenameLocals.sk
@@ -253,7 +253,6 @@ fun rename_locals(prog: O.Program): O.Program {
     rename_class_locals,
     rename_const_locals,
     rename_function_locals,
-    id,
     prog,
   )
 }


### PR DESCRIPTION
The type aliases are expanded during the type-checking phase,
there is no need to keep them around.