### PR TITLE
Remove get() and unsafe_get() from String

### DIFF
--- a/src/frontend/SkipLexer.sk
+++ b/src/frontend/SkipLexer.sk
@@ -480,8 +480,10 @@ mutable class SkipCoreLexer extends SkipLexer {
   ): Token.Token {
     this.skipIdentifierChars();
     value = this.getTokenText(start);
-    invariant(value.startsWith("#"));
-    if (value.length() < 2 || !isIdentifierStartChar(value[1])) {
+    it = value.getIter();
+    invariant(it.next().test(ch ~> ch == '#'));
+    nextChar = it.next();
+    if (!nextChar.test(isIdentifierStartChar)) {
       this.addAndCreateError(
         start,
         errorMissingMacroIdentifier,
@@ -489,7 +491,7 @@ mutable class SkipCoreLexer extends SkipLexer {
       );
     } else if (Keywords.isKeyword(value)) {
       this.createToken(start, Keywords.toKeyword(value), includeTrailingTrivia)
-    } else if (Chars.isUpperCaseLetter(value[1])) {
+    } else if (nextChar.test(Chars.isUpperCaseLetter)) {
       this.createToken(
         start,
         TokenKind.MACRO_TYPE_IDENTIFIER(),

--- a/src/frontend/skipComment.sk
+++ b/src/frontend/skipComment.sk
@@ -25,9 +25,9 @@ extension class Comment {
   fun contents(): String {
     v = this.value;
     this.kind match {
-    | LineComment() -> v.getIter().forward(2).takeString()
+    | LineComment() -> v.getIter().forward(2).collectString()
     | DelimitedComment() ->
-      v.getIter().forward(2).takeUntil(v.getEndIter().rewind(2))
+      v.getIter().forward(2).slice(v.getEndIter().rewind(2))
     }
   }
 }

--- a/src/frontend/skipComment.sk
+++ b/src/frontend/skipComment.sk
@@ -23,9 +23,11 @@ extension class Comment {
   // The contents of the comment not including leading //, /* or trailing */
   // Does include the trailing NewLine for // comments if present.
   fun contents(): String {
+    v = this.value;
     this.kind match {
-    | LineComment() -> this.value.sub(2, this.value.length() - 2)
-    | DelimitedComment() -> this.value.sub(2, this.value.length() - 4)
+    | LineComment() -> v.getIter().forward(2).takeString()
+    | DelimitedComment() ->
+      v.getIter().forward(2).takeUntil(v.getEndIter().rewind(2))
     }
   }
 }

--- a/src/frontend/skipDidYouMean.sk
+++ b/src/frontend/skipDidYouMean.sk
@@ -34,9 +34,11 @@ fun levenshteinDistance(s: String, t: String): Int {
     set(w, d, 0, j, j);
   };
 
-  for (j in Range(1, n + 1)) {
-    for (i in Range(1, m + 1)) {
-      if (s[i - 1] == t[j - 1]) {
+  j = 1;
+  for (tCh in t) {
+    i = 1;
+    for (sCh in s) {
+      if (sCh == tCh) {
         set(w, d, i, j, get(w, d, i - 1, j - 1))
       } else {
         set(
@@ -50,8 +52,10 @@ fun levenshteinDistance(s: String, t: String): Int {
             get(w, d, i - 1, j - 1) + 1,
           ),
         )
-      }
-    }
+      };
+      !i = i + 1;
+    };
+    !j = j + 1;
   };
 
   get(w, d, m, n)

--- a/src/frontend/skipExpand.sk
+++ b/src/frontend/skipExpand.sk
@@ -182,7 +182,7 @@ untracked fun populateCache(moduleDefs: SkipExpand.Module_map_t): void {
   pushDef = (prefix, fileName, moduleName, defName) -> {
     if (defName.startsWith(".")) {
       !moduleName = "U";
-      !defName = defName.getIter().forward(1).takeString();
+      !defName = defName.getIter().forward(1).collectString();
     };
     !defName = prefix + defName;
     fileDefs = fileMap.getOrAdd(fileName, () -> mutable Map[]);
@@ -373,7 +373,7 @@ fun module_map_fold(moduleMap: Module_map_t): A.Program {
           pos_opt match {
           | None() -> invariant_violation("ICE no pos for module_map_fold")
           | Some(pos) ->
-            Module((pos, moduleName.getIter().forward(1).takeString()))
+            Module((pos, moduleName.getIter().forward(1).collectString()))
           }
         }
       };
@@ -469,7 +469,7 @@ fun make_qualified_name(
   dotted_name = str.startsWith(".");
   (module_, name) match {
   | (Module((_, _)), _) if (dotted_name) ->
-    (pos, str.getIter().forward(1).takeString())
+    (pos, str.getIter().forward(1).collectString())
   | (Unqualified(), _) if (dotted_name) ->
     SkipError.error(
       pos,
@@ -634,7 +634,7 @@ fun current_defs_names(env: Env): DefNames {
 fun cstr_name(env: Env, name: (FileRange, String)): (FileRange, String) {
   if (name.i1.startsWith(".")) {
     (namePos, nameStr) = name;
-    !nameStr = nameStr.getIter().forward(1).takeString();
+    !nameStr = nameStr.getIter().forward(1).collectString();
     make_qualified_name(namePos, Unqualified(), (namePos, nameStr))
   } else {
     mdefs = current_defs_names(env);

--- a/src/frontend/skipExpand.sk
+++ b/src/frontend/skipExpand.sk
@@ -180,9 +180,9 @@ fun containsKey(key: String): Bool {
 untracked fun populateCache(moduleDefs: SkipExpand.Module_map_t): void {
   fileMap = mutable Map[];
   pushDef = (prefix, fileName, moduleName, defName) -> {
-    if (defName[0] == '.') {
+    if (defName.startsWith(".")) {
       !moduleName = "U";
-      !defName = defName.substring(1);
+      !defName = defName.getIter().forward(1).takeString();
     };
     !defName = prefix + defName;
     fileDefs = fileMap.getOrAdd(fileName, () -> mutable Map[]);
@@ -366,14 +366,14 @@ fun module_map_fold(moduleMap: Module_map_t): A.Program {
     .map((moduleName, posDefs) -> {
       (pos_opt, defs) = posDefs;
       module_name = {
-        kind = moduleName.sub(0, 1);
+        kind = moduleName.take(1);
         if (kind == "U") {
           Unqualified()
         } else {
           pos_opt match {
           | None() -> invariant_violation("ICE no pos for module_map_fold")
           | Some(pos) ->
-            Module((pos, moduleName.sub(1, moduleName.length() - 1)))
+            Module((pos, moduleName.getIter().forward(1).takeString()))
           }
         }
       };
@@ -442,16 +442,7 @@ class ExprState{
 /*****************************************************************************/
 fun is_uppercase(nm: A.Name): Bool {
   (_, name) = nm;
-  name.length() == 0 ||
-    ({
-      name[0] match {
-      | 'A' | 'B' | 'C' | 'D' | 'E' | 'F' | 'G' | 'H' | 'I' | 'J' | 'K' | 'L'
-      | 'M' | 'N' | 'O' | 'P' | 'Q' | 'R' | 'S' | 'T' | 'U' | 'V' | 'W' | 'X'
-      | 'Y' | 'Z' ->
-        true
-      | _ -> false
-      }
-    })
+  name.isEmpty() || name.getIter().next().test(Chars.isUpperCaseLetter)
 }
 
 fun expand_module_name<Ta>(_env: Ta, mod_name: A.Name): Module_ {
@@ -475,9 +466,10 @@ fun make_qualified_name(
   name: (FileRange, String),
 ): (FileRange, String) {
   (_, str) = name;
-  dotted_name = str[0] == '.';
+  dotted_name = str.startsWith(".");
   (module_, name) match {
-  | (Module((_, _)), _) if (dotted_name) -> (pos, str.sub(1, str.length() - 1))
+  | (Module((_, _)), _) if (dotted_name) ->
+    (pos, str.getIter().forward(1).takeString())
   | (Unqualified(), _) if (dotted_name) ->
     SkipError.error(
       pos,
@@ -640,9 +632,9 @@ fun current_defs_names(env: Env): DefNames {
 /* Apply type names. */
 /*****************************************************************************/
 fun cstr_name(env: Env, name: (FileRange, String)): (FileRange, String) {
-  if (name.i1[0] == '.') {
+  if (name.i1.startsWith(".")) {
     (namePos, nameStr) = name;
-    !nameStr = nameStr.substring(1);
+    !nameStr = nameStr.getIter().forward(1).takeString();
     make_qualified_name(namePos, Unqualified(), (namePos, nameStr))
   } else {
     mdefs = current_defs_names(env);

--- a/src/frontend/skipToken.sk
+++ b/src/frontend/skipToken.sk
@@ -9,7 +9,11 @@ module Token;
 
 extension class Token{} {
   fun stringLiteralValue(): String {
-    stringValue(this.value.sub(1, this.value.length() - 2))
+    stringValue(
+      this.value.getIter()
+        .forward(1)
+        .takeUntil(this.value.getEndIter().rewind(1)),
+    )
   }
 
   fun templateStringLiteralValue(): String {
@@ -17,7 +21,11 @@ extension class Token{} {
   }
 
   fun charLiteralValue(): Char {
-    charLiteral(this.value.sub(1, this.value.length() - 2))
+    charLiteral(
+      this.value.getIter()
+        .forward(1)
+        .takeUntil(this.value.getEndIter().rewind(1)),
+    )
   }
 
   fun isHexLiteralToken(): Bool {
@@ -36,7 +44,7 @@ extension class Token{} {
     if (isIntMinString(value)) {
       Int::min
     } else if (isHexLiteralString(value)) {
-      Chars.hexDigitsToInt(value.sub(2, value.length() - 2))
+      Chars.hexDigitsToInt(value.getIter().forward(2).takeString())
     } else {
       value.toInt()
     }
@@ -72,31 +80,37 @@ fun isHexLiteralString(value: String): Bool {
 }
 
 fun charLiteralCode(value: String): Int {
-  if (value[0] != '\\') {
-    value[0].code()
-  } else {
-    value[1] match {
-    | '0' -> 0x00
-    | 'a' -> 0x07
-    | 'b' -> 0x08
-    | 'e' -> 0x1B
-    | 'f' -> 0x0C
-    | 'n' -> 0x0A
-    | 'r' -> 0x0D
-    | 't' -> 0x09
-    | 'v' -> 0x0B
-    | '\\' -> 0x5C
-    | '\'' -> 0x27
-    | '"' -> 0x22
-    | '`' -> 0x60
-    | '$' -> 0x24
-    | '{' -> 0x7B
-    | 'x' -> Chars.hexDigitsToInt(value.sub(2, 2))
-    | 'u' -> Chars.hexDigitsToInt(value.sub(2, 4))
-    | 'U' -> Chars.hexDigitsToInt(value.sub(2, 8))
-    | _ -> invariant_violation("Unexpected simple char escape")
+  i = value.getIter();
+  i.next() match {
+  | Some(ch) if (ch != '\\') -> ch.code()
+  | Some _ ->
+    i.next() match {
+    | Some(ch) ->
+      ch match {
+      | '0' -> 0x00
+      | 'a' -> 0x07
+      | 'b' -> 0x08
+      | 'e' -> 0x1B
+      | 'f' -> 0x0C
+      | 'n' -> 0x0A
+      | 'r' -> 0x0D
+      | 't' -> 0x09
+      | 'v' -> 0x0B
+      | '\\' -> 0x5C
+      | '\'' -> 0x27
+      | '"' -> 0x22
+      | '`' -> 0x60
+      | '$' -> 0x24
+      | '{' -> 0x7B
+      | 'x' -> Chars.hexDigitsToInt(String::fromChars(i.take(2).collect(Array)))
+      | 'u' -> Chars.hexDigitsToInt(String::fromChars(i.take(4).collect(Array)))
+      | 'U' -> Chars.hexDigitsToInt(String::fromChars(i.take(8).collect(Array)))
+      | _ -> invariant_violation("Unexpected simple char escape")
+      }
+    | None() -> invariant_violation("Unexpected end of string after escape")
     }
-  }
+  | None() -> -1
+  };
 }
 
 fun charLiteral(value: String): Char {

--- a/src/frontend/skipToken.sk
+++ b/src/frontend/skipToken.sk
@@ -10,9 +10,7 @@ module Token;
 extension class Token{} {
   fun stringLiteralValue(): String {
     stringValue(
-      this.value.getIter()
-        .forward(1)
-        .takeUntil(this.value.getEndIter().rewind(1)),
+      this.value.getIter().forward(1).slice(this.value.getEndIter().rewind(1)),
     )
   }
 
@@ -22,9 +20,7 @@ extension class Token{} {
 
   fun charLiteralValue(): Char {
     charLiteral(
-      this.value.getIter()
-        .forward(1)
-        .takeUntil(this.value.getEndIter().rewind(1)),
+      this.value.getIter().forward(1).slice(this.value.getEndIter().rewind(1)),
     )
   }
 
@@ -44,7 +40,7 @@ extension class Token{} {
     if (isIntMinString(value)) {
       Int::min
     } else if (isHexLiteralString(value)) {
-      Chars.hexDigitsToInt(value.getIter().forward(2).takeString())
+      Chars.hexDigitsToInt(value.getIter().forward(2).collectString())
     } else {
       value.toInt()
     }

--- a/src/js/vlq.sk
+++ b/src/js/vlq.sk
@@ -48,11 +48,18 @@ fun vlq_signed_of_int(value: Int): Int {
 }
 
 /* Base64 mapping */
-const base64: String = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+// printer-ignore
+const base64: Array<Char> = Array[
+  'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O',
+  'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', 'a', 'b', 'c', 'd',
+  'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's',
+  't', 'u', 'v', 'w', 'x', 'y', 'z', '0', '1', '2', '3', '4', '5', '6', '7',
+  '8', '9', '+', '/',
+];
 
 /* Encode an integer in the range of 0 to 63 to a single base 64 digit */
 fun base64_char_of_int(number: Int): Char {
-  if ((0 <= number) && (number < base64.length())) {
+  if ((0 <= number) && (number < base64.size())) {
     base64[number]
   } else {
     invariant_violation("Must be between 0 and 63: " + number)

--- a/src/native/AsmOutput.sk
+++ b/src/native/AsmOutput.sk
@@ -1292,8 +1292,9 @@ private fun needsQuotes(s: String): Bool {
 // This needs to be made reversible and deal correctly with name clashes.
 // See T22100866
 private fun mangle(name: String): String {
-  String::tabulate(name.length(), i -> {
-    name[i] match {
+  i = name.getIter();
+  String::tabulate(name.length(), _ -> {
+    i.next().fromSome() match {
     | '+' | '-' | '.' | ':' -> '_'
     | '!' -> 'N'
     | '=' -> 'E'
@@ -1680,7 +1681,7 @@ fun prettyText(s: String): String {
     if (s.length() <= limit) {
       s
     } else {
-      s.sub(0, limit)
+      s.take(limit)
     },
   )
 }
@@ -4308,7 +4309,9 @@ fun llvmWriteFunctionDefinition(
   for (ref in asm.refs) {
     asm.declarationRefs.push((ref.i0 + refOffsetDelta, ref.i1))
   };
-  asm.declarationText.write(asm.text.toString().substring(defineEndOffset));
+  asm.declarationText.write(
+    asm.text.toString().getIter().forward(defineEndOffset).takeString(),
+  );
   asm.declarationText.writeChar('\n');
 
   asm.print(

--- a/src/native/AsmOutput.sk
+++ b/src/native/AsmOutput.sk
@@ -97,7 +97,8 @@ extension class .String uses AsmFormattable {
     | 'r' ->
       text.writeChar('\"');
 
-      for (b in UTF8String::make(this).utf8) {
+      for (b_ in UTF8String::make(this).utf8) {
+        b = b_.toInt();
         if (
           b >= 0x20 /* ' ' */ &&
           b < 0x7F &&
@@ -2131,7 +2132,9 @@ mutable class .AsmOutput{
                 // padded character data
                 utf8Index = n - 2;
                 StaticImageField(
-                  kByteConstants[str.utf8.maybeGet(utf8Index).default(0)],
+                  kByteConstants[
+                    str.utf8.maybeGet(utf8Index).default(UInt8::zero).toInt(),
+                  ],
                   64 + utf8Index * 8,
                 )
               },
@@ -2150,7 +2153,7 @@ mutable class .AsmOutput{
       createStaticImage{
         getField => i ~>
           s.utf8.maybeGet(i).map(n ->
-            StaticImageField(kByteConstants[n], i * 8)
+            StaticImageField(kByteConstants[n.toInt()], i * 8)
           ),
         common => this,
         symbolNameHint => ".cstr." + prettyText(s.string),

--- a/src/native/AsmOutput.sk
+++ b/src/native/AsmOutput.sk
@@ -4310,7 +4310,7 @@ fun llvmWriteFunctionDefinition(
     asm.declarationRefs.push((ref.i0 + refOffsetDelta, ref.i1))
   };
   asm.declarationText.write(
-    asm.text.toString().getIter().forward(defineEndOffset).takeString(),
+    asm.text.toString().getIter().forward(defineEndOffset).collectString(),
   );
   asm.declarationText.writeChar('\n');
 

--- a/src/native/IR.sk
+++ b/src/native/IR.sk
@@ -144,7 +144,8 @@ base class UTF8String{
     backEndUsesUtf8 = ("\u1234".length() != 1);
 
     utf8 = if (backEndUsesUtf8) {
-      Array::fillBy(string.length(), i -> string[i].code())
+      i = string.getIter();
+      Array::fillBy(string.length(), _ -> i.next().fromSome().code())
     } else {
       // UCS4 code points.
       vector = mutable Vector<Int>[];

--- a/src/native/IR.sk
+++ b/src/native/IR.sk
@@ -132,7 +132,7 @@ class GlobalEnv{
 // A UTF8-encoded string that knows its Skip checksum.
 base class UTF8String{
   // Although this says Int, they are guaranteed to be bytes [0, 255].
-  utf8: Array<Int>,
+  utf8: Array<UInt8>,
   string: String,
 } uses Hashable, Orderable, Show {
   static fun useShortStrings(): Bool {
@@ -140,20 +140,7 @@ base class UTF8String{
   }
 
   static fun make(string: String): UTF8String {
-    // Some of our back ends already expose utf8 from the string, some don't.
-    backEndUsesUtf8 = ("\u1234".length() != 1);
-
-    utf8 = if (backEndUsesUtf8) {
-      i = string.getIter();
-      Array::fillBy(string.length(), _ -> i.next().fromSome().code())
-    } else {
-      // UCS4 code points.
-      vector = mutable Vector<Int>[];
-      vector.ensureCapacity(string.length());
-      for (c in string) c.utf8Encode().each(vector.push);
-      vector.toArray()
-    };
-
+    utf8 = string.utf8().collect(Array);
     if (utf8.size() < ptrByteSize && static::useShortStrings()) {
       ShortUTF8String{utf8, string}
     } else {
@@ -218,7 +205,7 @@ class ShortUTF8String extends UTF8String {
 }
 
 class LongUTF8String{runtimeHash: Int} extends UTF8String {
-  static fun makeLong(utf8: Array<Int>, string: String): LongUTF8String {
+  static fun makeLong(utf8: Array<UInt8>, string: String): LongUTF8String {
     invariant(
       utf8.size() >= 8 || !UTF8String::useShortStrings(),
       "This is not a long string.",

--- a/src/native/PrettyIR.sk
+++ b/src/native/PrettyIR.sk
@@ -101,7 +101,8 @@ extension class .String uses PrettyFormattable {
     | 's' -> text.writeString(this)
     | 'r' ->
       text.writeChar('\"');
-      for (b in UTF8String::make(this).utf8) {
+      for (b_ in UTF8String::make(this).utf8) {
+        b = b_.toInt();
         if (
           b >= 0x20 /* ' ' */ &&
           b < 0x7F &&

--- a/src/native/PrettyIR.sk
+++ b/src/native/PrettyIR.sk
@@ -623,8 +623,9 @@ private fun needsQuotes(s: String): Bool {
 // This needs to be made reversible and deal correctly with name clashes.
 // See T22100866
 private fun mangle(name: String): String {
-  String::tabulate(name.length(), i -> {
-    name[i] match {
+  i = name.getIter();
+  String::tabulate(name.length(), _ -> {
+    i.next().fromSome() match {
     | '+' | '-' | '.' | ':' -> '_'
     | '!' -> 'N'
     | '=' -> 'E'
@@ -994,7 +995,7 @@ fun prettyText(s: String): String {
     if (s.length() <= limit) {
       s
     } else {
-      s.sub(0, limit)
+      s.take(limit)
     },
   )
 }

--- a/src/native/TextOutputStream.sk
+++ b/src/native/TextOutputStream.sk
@@ -54,7 +54,7 @@ mutable base class .TextOutputStream {
   overridable mutable fun writeHex(n: Int, numDigits: Int): void {
     for (i in Range(0, numDigits)) {
       nibble = n.shr((numDigits - i - 1) * 4).and(0xF);
-      this.writeChar("0123456789abcdef"[nibble])
+      this.writeChar(Chars.intToHexDigit(nibble))
     }
   }
 

--- a/src/native/TextOutputStream.sk
+++ b/src/native/TextOutputStream.sk
@@ -75,16 +75,14 @@ mutable base class .TextOutputStream {
   }
 
   // Write a string to out, escaping unprintable or non-ASCII characters.
-  mutable fun writeEscapedBytes<T: Sequence<Int>>(bytes: T): void {
+  mutable fun writeEscapedBytes<T: Sequence<UInt8>>(bytes: T): void {
     for (b in bytes) {
-      invariant(b >= 0 && b <= 0xff, "Expected byte values.");
-
-      c = Char::fromCode(b);
+      c = Char::fromCode(b.toInt());
       if (c >= ' ' && c < '\x7F' && c != '\"' && c != '\\') {
         this.writeChar(c)
       } else {
         this.write("\\x");
-        this.writeHex(b, 2)
+        this.writeHex(b.toInt(), 2)
       }
     }
   }

--- a/src/native/checksum.sk
+++ b/src/native/checksum.sk
@@ -25,25 +25,27 @@ fun toInt31(i32: Int): Int {
   i32.shl(33).shr(1).ushr(32)
 }
 
-fun computeWasmStringHash(utf8: Array<Int>): Int {
-  toInt31(utf8.foldl((acc, ch) -> acc * 31 + ch, 0))
+fun computeWasmStringHash(utf8: Array<UInt8>): Int {
+  toInt31(utf8.foldl((acc, ch) -> acc * 31 + ch.toInt(), 0))
 }
 
-fun computeNativeStringHash(utf8: Array<Int>): Int {
+fun computeNativeStringHash(utf8: Array<UInt8>): Int {
   acc = 0xFFFFFFFF;
   rem = utf8.size() % 8;
   split = utf8.size() - rem;
-  for (idx in Range(0, split)) !acc = crc32_u8(acc, utf8[idx].and(0xdf));
+  for (idx in Range(0, split)) {
+    !acc = crc32_u8(acc, utf8[idx].toInt().and(0xdf))
+  };
   if (rem != 0) {
     for (_ in Range(0, 8 - rem)) !acc = crc32_u8(acc, 0);
     for (idx in Range(0, rem)) {
-      !acc = crc32_u8(acc, utf8[split + idx].and(0xdf))
+      !acc = crc32_u8(acc, utf8[split + idx].toInt().and(0xdf))
     };
   };
   acc.shr(1).or(0x80000000)
 }
 
-fun computeStringHash(utf8: Array<Int>): Int {
+fun computeStringHash(utf8: Array<UInt8>): Int {
   if (targetIsWasm()) {
     computeWasmStringHash(utf8)
   } else {

--- a/src/native/vtable.sk
+++ b/src/native/vtable.sk
@@ -705,7 +705,7 @@ private fun createGCType(sc: SClass, env: GlobalEnv): ConstantStruct {
         sc.gclassName.id + "<...>"
       },
     );
-    for (c in name.utf8) pushField(kByteConstants[c]);
+    for (c in name.utf8) pushField(kByteConstants[c.toInt()]);
     pushField(kByteConstants[0]);
   };
 

--- a/src/nuclide/languageServerProtocol.sk
+++ b/src/nuclide/languageServerProtocol.sk
@@ -37,7 +37,11 @@ untracked fun readMessage(log: String -> void): String {
   // Skip the extra \r\n
   extraLine = read_line();
   invariant(extraLine == "\r");
-  length = line.sub(contentLength, line.length() - contentLength - 1).toInt();
+  length = line
+    .getIter()
+    .forward(contentLength)
+    .takeUntil(line.getEndIter().rewind(1))
+    .toInt();
   read_stdin_bytes(length)
 }
 

--- a/src/nuclide/languageServerProtocol.sk
+++ b/src/nuclide/languageServerProtocol.sk
@@ -40,7 +40,7 @@ untracked fun readMessage(log: String -> void): String {
   length = line
     .getIter()
     .forward(contentLength)
-    .takeUntil(line.getEndIter().rewind(1))
+    .slice(line.getEndIter().rewind(1))
     .toInt();
   read_stdin_bytes(length)
 }

--- a/src/project/SolutionLoader.sk
+++ b/src/project/SolutionLoader.sk
@@ -670,7 +670,7 @@ mutable class SolutionLoader{
       directoryFilter = excludes.default(_ ~> true);
       files = if (resolvedPath.endsWith("**")) {
         recursiveDir = Path.normalize(
-          resolvedPath.sub(0, resolvedPath.length() - 2),
+          resolvedPath.take(resolvedPath.length() - 2),
         );
         if (!FileSystem.isDirectory(recursiveDir)) {
           this.addError(

--- a/src/runtime/js/lib/string.js
+++ b/src/runtime/js/lib/string.js
@@ -225,17 +225,20 @@ module.exports = function(sk) {
         return this.__value;
       },
       'sub': function(start, len) {
-        start = sk.__.intToNumber(start);
-        len = sk.__.intToNumber(len);
+        start = sk.__.intToNumber(start.i);
+        var end = start + sk.__.intToNumber(len);
         const this_len = lengthOfString(this);
-        if(start < 0 || len < 0 || (start + len) > this_len) {
-          throwOutOfBounds(start + len);
+        if (start < 0) {
+          start = 0;
         }
-        if (start === 0 && len === this_len) {
+        if (end > this_len) {
+          end = this_len;
+        }
+        if (start === 0 && end === this_len) {
           return this;
         }
         const startIndex = indexOfChar(this.__value, getHasCombiningChars(this), start);
-        const endIndex = indexOfChar(this.__value, getHasCombiningChars(this), start + len);
+        const endIndex = indexOfChar(this.__value, getHasCombiningChars(this), end);
         return new String_(this.__value.substring(startIndex, endIndex), len !== (endIndex - startIndex));
       },
       'get': function(index) {

--- a/src/runtime/native/include/skip/String-extc.h
+++ b/src/runtime/native/include/skip/String-extc.h
@@ -46,6 +46,7 @@ extern SkipString SKIP_String_StringIterator__substring(
     SkipRObj* end);
 extern SkipInt SKIP_String_StringIterator__rawCurrent(SkipRObj* i);
 extern SkipInt SKIP_String_StringIterator__rawNext(SkipRObj* i);
+extern SkipInt SKIP_String_StringIterator__rawPrev(SkipRObj* i);
 extern void SKIP_String_StringIterator__rawDrop(SkipRObj* i, SkipInt n);
 extern SkipInt SKIP_String__length(SkipString s);
 

--- a/src/runtime/native/src/String.cpp
+++ b/src/runtime/native/src/String.cpp
@@ -475,6 +475,17 @@ struct StringIterator final : RObj {
     return rawCurrentImpl(m_byteOffset);
   }
 
+  int64_t rawPrev() {
+    if (m_byteOffset == 0) {
+      return -1;
+    }
+    UChar32 ch = 0;
+    int32_t offset = m_byteOffset;
+    U8_PREV(m_string.unsafeData(), 0, offset, ch);
+    m_byteOffset = offset;
+    return ch;
+  }
+
   void rawDrop(int64_t n) {
     if (n < 0) {
       SKIP_throwInvariantViolation(
@@ -697,6 +708,10 @@ SkipInt SKIP_String_StringIterator__rawCurrent(RObj* i) {
 
 SkipInt SKIP_String_StringIterator__rawNext(RObj* i) {
   return i->cast<StringIterator>().rawNext();
+}
+
+SkipInt SKIP_String_StringIterator__rawPrev(RObj* i) {
+  return i->cast<StringIterator>().rawPrev();
 }
 
 void SKIP_String_StringIterator__rawDrop(RObj* i, SkipInt n) {

--- a/src/runtime/prelude/core/language/Iterator.sk
+++ b/src/runtime/prelude/core/language/Iterator.sk
@@ -131,6 +131,20 @@ mutable base class .Iterator<+T> {
     mutable ZipIterator(this, other)
   }
 
+  // Returns a new iterator representing the tuples of the ith elements of this
+  // and the other iterator.  Unlike zip(), zipLongest() continues until both
+  // iterators are exhausted.
+  overridable mutable fun zipLongest<U>(
+    other: mutable Iterator<U>,
+  ): mutable Iterator<(?T, ?U)> {
+    loop {
+      (this.next(), other.next()) match {
+      | (None(), None()) -> break void
+      | i @ _ -> yield i
+      }
+    }
+  }
+
   // Returns a new iterator representing the results of calling the selection
   // function with tuples of the ith elements of this and the other iterator.
   overridable mutable fun zipWith<U, V>(
@@ -183,14 +197,11 @@ mutable base class .Iterator<+T> {
   // Returns Some(x) for the first item in this iterator that matches
   // the predicate, or None() if no items match.
   overridable mutable fun find(p: T -> Bool): ?T {
-    flag = true;
-    do
+    loop {
       this.next() match {
       | Some(x) -> if (p(x)) break Some(x)
-      | None() -> !flag = false
+      | None() -> break None()
       }
-     while (flag) else {
-      None()
     }
   }
 
@@ -290,7 +301,7 @@ mutable class TakeIterator<+T>(
   private mutable n: Int,
 ) extends Iterator<T> {
   readonly fun sizeHint(): ?Int {
-    this.base.sizeHint().map(sizeHint -> min(0, sizeHint - this.n))
+    this.base.sizeHint().map(sizeHint -> max(0, sizeHint - this.n))
   }
 
   mutable fun next(): ?T {

--- a/src/runtime/prelude/core/primitives/Int.sk
+++ b/src/runtime/prelude/core/primitives/Int.sk
@@ -247,6 +247,12 @@ native value class Int uses Number, Integral {
     });
   }
 
+  fun toStringHex(): String {
+    String::tabulate(16, i ~> {
+      Chars.intToHexDigit(this.ushr((15 - i) * 4).and(0xF))
+    })
+  }
+
   fun toString(): String {
     this.toStringImpl()
   }

--- a/src/runtime/prelude/core/primitives/String.sk
+++ b/src/runtime/prelude/core/primitives/String.sk
@@ -15,9 +15,9 @@ native class .String uses Hashable, Show, Orderable {
   @may_alloc
   native static fun fromUtf8(bytes: readonly Array<UInt8>): String;
 
-  // Careful, this is O(n) (because of utf8)
-  @cpp_runtime
-  native private fun unsafe_get(x: Int): Char;
+  static fun fromGenerator(gen: () -> mutable Iterator<Char>): String {
+    String::fromChars(Array::createFromIterator(gen()))
+  }
 
   @cpp_runtime
   native fun length(): Int;
@@ -28,86 +28,62 @@ native class .String uses Hashable, Show, Orderable {
   @cpp_runtime
   native private fun compare_raw(other: String): Int;
 
-  fun sub(start: Int, len: Int): String {
-    this_len = this.length();
-    if (start == 0 && len == this_len) {
-      this
-    } else {
-      if (start < 0 || len < 0 || (start + len).ugt(this_len)) {
-        throwOutOfBounds()
-      };
+  fun take(len: Int): String {
+    this.getIter().takeString(len)
+  }
 
-      // We don't want to use unsafe_get because it is O(n)
-      subString = mutable Vector[];
-      iter = this.getIter().drop(start);
-      for (_ in Range(0, len)) {
-        subString.push(iter.next().fromSome())
-      };
-      static::fromChars(freeze(subString.toArray()))
-    }
+  fun sub(start: readonly StringIterator, len: Int): String {
+    start.clone().takeString(len)
   }
 
   fun inspect(): Inspect {
     InspectString(this)
   }
 
-  fun substring(start: Int): String {
-    this.sub(start, this.length() - start)
+  fun substring(start: readonly StringIterator): String {
+    start.substring(this.getEndIter())
   }
 
-  private static fun isPrefix(
-    it1: mutable StringIterator,
-    it2: mutable StringIterator,
-  ): Bool {
-    it1.next() match {
-    | None() -> true
-    | Some(c1) ->
-      it2.next() match {
-      | Some(c2) if (c1 == c2) -> static::isPrefix(it1, it2)
-      | _ -> false
+  frozen fun startsWith(prefix: String): Bool {
+    this.getIter().clone().startsWith(prefix.getIter())
+  }
+
+  frozen fun endsWith(suffix: String): Bool {
+    iThis = this.getEndIter();
+    iSuffix = suffix.getEndIter();
+    loop {
+      (iThis.prev(), iSuffix.prev()) match {
+      | (_, None()) -> break true
+      | (None(), _) -> break false
+      | (Some(a), Some(b)) if (a != b) -> break false
+      | _ -> void
       }
     }
   }
 
-  frozen fun startsWith(prefix: String): Bool {
-    mySize = this.length();
-    prefixSize = prefix.length();
-
-    mySize >= prefixSize && static::isPrefix(prefix.getIter(), this.getIter())
-  }
-
-  frozen fun endsWith(suffix: String): Bool {
-    mySize = this.length();
-    suffixSize = suffix.length();
-
-    mySize >= suffixSize &&
-      static::isPrefix(
-        suffix.getIter(),
-        this.getIter().drop(mySize - suffixSize),
-      )
-  }
-
   fun stripPrefix(prefix: String): String {
-    if (this.startsWith(prefix)) {
-      this.substring(prefix.length())
+    i = this.getIter();
+    if (i.startsWith(prefix.getIter())) {
+      i.substring(this.getEndIter())
     } else {
       this
     }
   }
 
   fun stripSuffix(suffix: String): String {
-    if (this.endsWith(suffix)) {
-      this.sub(0, this.length() - suffix.length())
-    } else {
-      this
+    i = this.getEndIter();
+    j = suffix.getEndIter();
+    loop {
+      (i.prev(), j.prev()) match {
+      | (None(), None()) -> break ""
+      | (_, None()) ->
+        _ = i.next();
+        break this.getIter().substring(i)
+      | (None(), _) -> break this
+      | (Some(a), Some(b)) if (a != b) -> break this
+      | _ -> void
+      };
     }
-  }
-
-  fun get(x: Int): Char {
-    if (x.uge(this.length())) {
-      throwOutOfBounds()
-    };
-    this.unsafe_get(x)
   }
 
   fun +<T: readonly Show>(s: T): String {
@@ -119,13 +95,13 @@ native class .String uses Hashable, Show, Orderable {
   }
 
   fun repeat(count: Int): String {
-    if (count <= 0) {
-      ""
-    } else {
-      String::tabulate(count * this.length(), i -> {
-        this[i % this.length()]
-      })
-    }
+    String::fromGenerator(() -> {
+      for (_ in Range(0, count)) {
+        for (c in this) {
+          yield c;
+        }
+      }
+    })
   }
 
   @cpp_runtime
@@ -143,18 +119,6 @@ native class .String uses Hashable, Show, Orderable {
       !result = f(result, ch)
     });
     result;
-  }
-
-  private fun foldlImpl<Taccum>(
-    f: (Taccum, Char) -> Taccum,
-    accum: Taccum,
-    offset: Int,
-  ): Taccum {
-    if (offset >= this.length()) {
-      accum
-    } else {
-      this.foldlImpl(f, f(accum, this[offset]), offset + 1)
-    }
   }
 
   fun toIntOption(): ?Int {
@@ -248,20 +212,18 @@ native class .String uses Hashable, Show, Orderable {
   }
 
   fun trimLeft(): String {
-    offset = this.search(0, ch ~> !isWhitespace(ch));
-    if (offset.isSome()) {
-      this.substring(offset.fromSome())
-    } else {
-      ""
+    this.search(ch ~> !isWhitespace(ch)) match {
+    | Some(i) -> i.substring(this.getEndIter())
+    | None() -> ""
     }
   }
 
   fun trimRight(): String {
-    offset = this.rsearch(this.length() - 1, ch ~> !isWhitespace(ch));
-    if (offset.isSome()) {
-      this.sub(0, offset.fromSome() + 1)
-    } else {
-      ""
+    this.rsearch(ch ~> !isWhitespace(ch)) match {
+    | Some(i) ->
+      _ = i.next();
+      this.getIter().substring(i)
+    | None() -> ""
     }
   }
 
@@ -269,113 +231,45 @@ native class .String uses Hashable, Show, Orderable {
     this.trimLeft().trimRight()
   }
 
-  fun search(offset: Int, f: Char -> Bool): ?Int {
-    if (offset.uge(this.length())) {
-      None()
-    } else if (f(this.unsafe_get(offset))) {
-      Some(offset)
-    } else {
-      this.search(offset + 1, f)
-    }
+  // Finds the given pattern in the string, starting from 'from'
+  fun search(f: Char -> Bool): ?mutable StringIterator {
+    i = this.getIter();
+    i.find(f).map(_ -> {
+      _ = i.prev();
+      i
+    })
   }
 
-  fun searchIndex(offset: Int, f: Char -> Bool): Int {
-    if (offset.uge(this.length())) {
-      -1
-    } else if (f(this.unsafe_get(offset))) {
-      offset
-    } else {
-      this.searchIndex(offset + 1, f)
-    }
-  }
-
-  fun rsearch(offset: Int, f: Char -> Bool): ?Int {
-    if (offset.uge(this.length())) {
-      None()
-    } else if (f(this.unsafe_get(offset))) {
-      Some(offset)
-    } else {
-      this.rsearch(offset - 1, f)
-    }
+  fun rsearch(f: Char -> Bool): ?mutable StringIterator {
+    i = this.getEndIter();
+    i.rfind(f).map(_ -> i)
   }
 
   fun chars(): Vector<Char> {
     this.getIter().collect(Vector)
   }
 
-  private static fun iterStartsWith(
-    value: readonly StringIterator,
-    prefix: readonly StringIterator,
-  ): Bool {
-    testValue = value.clone();
-    testPrefix = prefix.clone();
-    matched = false;
-    while ({
-      (testPrefix.next(), testValue.next()) match {
-      | (None(), _) ->
-        !matched = true;
-        false
-      | (Some(chPrefix), Some(chCurrent)) if (chPrefix == chCurrent) -> true
-      | _ -> false
-      };
-    }) void;
-    matched;
-  }
-
-  private static fun find(
-    value: readonly StringIterator,
-    substring: readonly StringIterator,
-  ): mutable StringIterator {
-    testValue = value.clone();
-    while (
-      !testValue.atEnd() &&
-      !static::iterStartsWith(testValue, substring)
-    ) _ = testValue.next();
-    testValue
-  }
-
-  private fun index(substring: String, offset: Int): ?Int {
-    if (offset > this.length() - substring.length()) {
-      None()
-    } else if (this.sub(offset, substring.length()) == substring) {
-      Some(offset)
-    } else {
-      this.index(substring, offset + 1)
-    }
-  }
-
   fun splitLast(substring: String): (String, String) {
-    a = this.length();
-    b = substring.length();
-    (a, b) match {
-    | (0, _) -> ("", "")
-    | (_, 0) -> (this, "")
-    | (_, 1) -> this.splitLastCharHelper(substring[0], a - 1)
-    | _ if (a < b) -> ("", this)
-    | _ -> this.splitLastHelper(substring, a - b)
+    i = this.getEndIter();
+    if (!i.rsearch(substring)) {
+      ("", this)
+    } else {
+      a = this.getIter().substring(i);
+      _ = i.drop(substring.length());
+      b = i.substring(this.getEndIter());
+      (a, b)
     }
   }
 
-  private fun splitLastCharHelper(ch: Char, offset: Int): (String, String) {
-    if (this.unsafe_get(offset) == ch) {
-      (this.sub(0, offset), this.substring(offset + 1))
-    } else if (offset > 0) {
-      this.splitLastCharHelper(ch, offset - 1)
+  fun splitFirst(substring: String): (String, String) {
+    i = this.getIter();
+    if (!i.search(substring)) {
+      (this, "")
     } else {
-      ("", this)
-    }
-  }
-
-  private fun splitLastHelper(
-    substring: String,
-    offset: Int,
-  ): (String, String) {
-    if (this.sub(offset, substring.length()) == substring) {
-      (this.sub(0, offset), this.substring(offset + substring.length()))
-    } else if (offset == 0) {
-      ("", this)
-    } else {
-      this.splitLastHelper(substring, offset - 1)
+      a = this.getIter().substring(i);
+      _ = i.drop(substring.length());
+      b = i.substring(this.getEndIter());
+      (a, b)
     }
   }
 
@@ -383,59 +277,46 @@ native class .String uses Hashable, Show, Orderable {
   native fun contains(search: String): Bool;
 
   fun replace(search: String, replacement: String): String {
-    if (search.length() == 0) {
-      this
-    } else {
-      res = this;
-      start = 0;
-      while ({
-        index_opt = res.index(search, start);
-        index_opt match {
-        | Some(index) ->
-          !start = index + replacement.length();
-          !res = String::tabulate(
-            res.length() - search.length() + replacement.length(),
-            i -> {
-              if (i < index) {
-                res[i]
-              } else if (i < index + replacement.length()) {
-                replacement[i - index]
-              } else {
-                res[i - replacement.length() + search.length()]
-              }
-            },
-          );
-          true
-        | None() -> false
-        }
-      }) void;
-      res
-    }
+    if (search.isEmpty()) {
+      return this;
+    };
+
+    String::fromGenerator(() -> {
+      i = this.getIter();
+      searchLength = search.length();
+      while (!i.atEnd()) {
+        start = i.clone();
+        if (!i.search(search)) {
+          !i = start;
+          break void;
+        };
+        for (c in start.substring(i)) yield c;
+        for (c in replacement) yield c;
+        _ = i.drop(searchLength);
+      };
+      for (c in i) yield c;
+    })
   }
 
-  fun split(delimiter: String): Vector<String> {
+  fun split(delimiter: String, maxCount: Int = Int::max): Vector<String> {
     delimiterLength = delimiter.length();
     if (delimiterLength == 0) {
       invariant_violation("String.split: cannot split with empty delimiter")
     } else if (this.isEmpty()) {
       Vector[""]
     } else {
-      vector = mutable Vector[];
-      current = this.getIter();
-      delimiterIter = delimiter.getIter();
-
-      while ({
-        end = static::find(current, delimiterIter);
-        vector.push(current.substring(end));
-        !current = end;
-        if (!current.atEnd()) {
-          _ = current.drop(delimiterLength);
-          true;
-        } else {
-          false;
+      gen: () -> mutable Iterator<String> = () -> {
+        start = this.getIter();
+        i = start.clone();
+        while (i.search(delimiter) && maxCount > 0) {
+          !maxCount = maxCount - 1;
+          yield start.substring(i);
+          _ = i.drop(delimiterLength);
+          !start = i.clone();
         };
-      }) void;
-      freeze(vector)
+        yield start.substring(this.getEndIter());
+      };
+      Vector::createFromIterator(gen());
     }
   }
 
@@ -444,34 +325,26 @@ native class .String uses Hashable, Show, Orderable {
   }
 
   fun padLeft(width: Int, chr: Char = ' '): String {
-    len = this.length();
-    if (len >= width) {
+    n = this.length();
+    if (width <= n) {
       this
     } else {
-      padCount = width - len;
-      String::tabulate(width, n -> {
-        if (n < padCount) {
-          chr
-        } else {
-          this[n - padCount]
-        }
+      String::fromGenerator(() -> {
+        for (_ in Range(0, width - n)) yield chr;
+        for (c in this) yield c;
       })
     }
   }
 
   fun padRight(width: Int, chr: Char = ' '): String {
-    len = this.length();
-    if (len >= width) {
-      this
-    } else {
-      String::tabulate(width, n -> {
-        if (n < len) {
-          this[n]
-        } else {
-          chr
-        }
-      })
-    }
+    String::fromGenerator(() -> {
+      count = 0;
+      for (c in this) {
+        !count = count + 1;
+        yield c;
+      };
+      for (_ in Range(count, width)) yield chr;
+    });
   }
 
   fun ==(other: String): Bool {
@@ -515,6 +388,10 @@ native class .String uses Hashable, Show, Orderable {
     StringIterator::make(this)
   }
 
+  fun getEndIter(): mutable StringIterator {
+    StringIterator::makeEnd(this)
+  }
+
   fun values(): mutable StringIterator {
     StringIterator::make(this)
   }
@@ -526,10 +403,7 @@ native class .String uses Hashable, Show, Orderable {
   @synonym("upcase")
   @synonym("uc")
   fun uppercase(): String {
-    chars = Array::fillBy(this.length(), index ->
-      this.unsafe_get(index).capitalize()
-    );
-    String::fromChars(chars)
+    String::fromChars(this.getIter().map(c -> c.capitalize()).collect(Array))
   }
 
   @synonym("toLowerCase")
@@ -539,38 +413,29 @@ native class .String uses Hashable, Show, Orderable {
   @synonym("downcase")
   @synonym("lc")
   fun lowercase(): String {
-    chars = Array::fillBy(this.length(), index ->
-      this.unsafe_get(index).uncapitalize()
-    );
-    String::fromChars(chars)
+    String::fromChars(this.getIter().map(c -> c.uncapitalize()).collect(Array))
   }
 
   fun uppercaseFirst(): String {
-    if (this.isEmpty()) {
-      this
-    } else {
-      first = this.unsafe_get(0);
-      first_capitalize = first.capitalize();
-      if (first == first_capitalize) {
-        this
-      } else {
-        `${first_capitalize}${this.substring(1)}`
-      }
-    }
+    String::fromGenerator(() -> {
+      i = this.getIter();
+      i.next() match {
+      | Some(ch) -> yield ch.capitalize()
+      | None() -> void
+      };
+      for (ch in i) yield ch;
+    });
   }
 
   fun lowercaseFirst(): String {
-    if (this.isEmpty()) {
-      this
-    } else {
-      first = this.unsafe_get(0);
-      first_uncapitalize = first.uncapitalize();
-      if (first == first_uncapitalize) {
-        this
-      } else {
-        `${first_uncapitalize}${this.substring(1)}`
-      }
-    }
+    String::fromGenerator(() -> {
+      i = this.getIter();
+      i.next() match {
+      | Some(ch) -> yield ch.uncapitalize()
+      | None() -> void
+      };
+      for (ch in i) yield ch;
+    });
   }
 }
 

--- a/src/runtime/prelude/core/primitives/String.sk
+++ b/src/runtime/prelude/core/primitives/String.sk
@@ -15,7 +15,7 @@ native class .String uses Hashable, Show, Orderable {
   @may_alloc
   native static fun fromUtf8(bytes: readonly Array<UInt8>): String;
 
-  static fun fromGenerator(gen: () -> mutable Iterator<Char>): String {
+  private static fun fromGenerator(gen: () -> mutable Iterator<Char>): String {
     String::fromChars(Array::createFromIterator(gen()))
   }
 
@@ -29,11 +29,11 @@ native class .String uses Hashable, Show, Orderable {
   native private fun compare_raw(other: String): Int;
 
   fun take(len: Int): String {
-    this.getIter().takeString(len)
+    this.getIter().collectString(len)
   }
 
   fun sub(start: readonly StringIterator, len: Int): String {
-    start.clone().takeString(len)
+    start.clone().collectString(len)
   }
 
   fun inspect(): Inspect {
@@ -219,7 +219,7 @@ native class .String uses Hashable, Show, Orderable {
   }
 
   fun trimRight(): String {
-    this.rsearch(ch ~> !isWhitespace(ch)) match {
+    this.searchRight(ch ~> !isWhitespace(ch)) match {
     | Some(i) ->
       _ = i.next();
       this.getIter().substring(i)
@@ -240,7 +240,7 @@ native class .String uses Hashable, Show, Orderable {
     })
   }
 
-  fun rsearch(f: Char -> Bool): ?mutable StringIterator {
+  fun searchRight(f: Char -> Bool): ?mutable StringIterator {
     i = this.getEndIter();
     i.rfind(f).map(_ -> i)
   }
@@ -251,7 +251,7 @@ native class .String uses Hashable, Show, Orderable {
 
   fun splitLast(substring: String): (String, String) {
     i = this.getEndIter();
-    if (!i.rsearch(substring)) {
+    if (!i.reverseSearch(substring)) {
       ("", this)
     } else {
       a = this.getIter().substring(i);

--- a/src/runtime/prelude/native/StringIterator.sk
+++ b/src/runtime/prelude/native/StringIterator.sk
@@ -18,8 +18,20 @@ mutable class StringIterator private (
     mutable StringIterator(s, 0)
   }
 
+  static fun makeEnd(s: String): mutable StringIterator {
+    mutable StringIterator(s, s.utf8().size())
+  }
+
   readonly fun clone(): mutable StringIterator {
     mutable StringIterator(this.s, this.i);
+  }
+
+  mutable fun assign(other: readonly StringIterator): void {
+    invariant(
+      this.s == other.s,
+      "Cannot assign from different string iterator",
+    );
+    this.!i = other.i;
   }
 
   private static fun charFromCodeOpt(code: Int): ?Char {
@@ -46,6 +58,10 @@ mutable class StringIterator private (
     static::charFromCodeOpt(this.rawNext());
   }
 
+  mutable fun prev(): ?Char {
+    static::charFromCodeOpt(this.rawPrev());
+  }
+
   mutable fun drop(n: Int): mutable StringIterator {
     this.rawDrop(n);
     this
@@ -59,5 +75,19 @@ mutable class StringIterator private (
   @cpp_runtime
   private mutable native fun rawNext(): Int;
   @cpp_runtime
+  private mutable native fun rawPrev(): Int;
+  @cpp_runtime
   private mutable native fun rawDrop(n: Int): void;
+
+  readonly fun <(other: readonly StringIterator): Bool {
+    this.i < other.i
+  }
+
+  readonly fun >(other: readonly StringIterator): Bool {
+    this.i > other.i
+  }
+
+  readonly fun ==(other: readonly StringIterator): Bool {
+    this.i == other.i
+  }
 }

--- a/src/runtime/prelude/nonnative/String.sk
+++ b/src/runtime/prelude/nonnative/String.sk
@@ -9,6 +9,9 @@ module String;
 
 extension class .String {
   native fun utf8(): IndexedSequence<UInt8>;
+
+  // This function is only defined for the non-native backend.  Don't use it.
+  native fun unsafe_get(x: Int): Char;
 }
 
 // This is only parameterized on T because changing that to UInt8 causes a

--- a/src/runtime/prelude/nonnative/StringIterator.sk
+++ b/src/runtime/prelude/nonnative/StringIterator.sk
@@ -78,14 +78,15 @@ mutable class StringIterator private (
       "Called StringIterator::substring with end before start",
     );
     i = this.clone();
-    String::fromGenerator(() -> {
+    gen: () -> mutable Iterator<Char> = () -> {
       while (i.i != end.i) {
         i.next() match {
         | Some(ch) -> yield ch
         | None() -> break void
         }
       }
-    })
+    };
+    String::fromChars(Array::createFromIterator(gen()))
   }
 
   readonly fun <(other: readonly StringIterator): Bool {

--- a/src/runtime/prelude/nonnative/StringIterator.sk
+++ b/src/runtime/prelude/nonnative/StringIterator.sk
@@ -16,8 +16,21 @@ mutable class StringIterator private (
     mutable StringIterator(s, 0, s.length())
   }
 
+  static fun makeEnd(s: String): mutable StringIterator {
+    len = s.length();
+    mutable StringIterator(s, len, len)
+  }
+
   readonly fun clone(): mutable StringIterator {
     mutable StringIterator(this.s, this.i, this.length);
+  }
+
+  mutable fun assign(other: readonly StringIterator): void {
+    invariant(
+      this.s == other.s,
+      "Cannot assign from different string iterator",
+    );
+    this.!i = other.i;
   }
 
   mutable fun drop(n: Int): mutable StringIterator {
@@ -34,7 +47,7 @@ mutable class StringIterator private (
     if (this.atEnd()) {
       None()
     } else {
-      Some(this.s.get(this.i));
+      Some(this.s.unsafe_get(this.i));
     }
   }
 
@@ -47,10 +60,43 @@ mutable class StringIterator private (
     if (result.isSome()) {
       this.!i = this.i + 1;
     };
-    result;
+    result
+  }
+
+  mutable fun prev(): ?Char {
+    if (this.i == 0) {
+      None()
+    } else {
+      this.!i = this.i - 1;
+      this.current()
+    }
   }
 
   readonly fun substring(end: readonly StringIterator): String {
-    this.s.sub(this.i, end.i - this.i);
+    invariant(
+      end.i >= this.i,
+      "Called StringIterator::substring with end before start",
+    );
+    i = this.clone();
+    String::fromGenerator(() -> {
+      while (i.i != end.i) {
+        i.next() match {
+        | Some(ch) -> yield ch
+        | None() -> break void
+        }
+      }
+    })
+  }
+
+  readonly fun <(other: readonly StringIterator): Bool {
+    this.i < other.i
+  }
+
+  readonly fun >(other: readonly StringIterator): Bool {
+    this.i > other.i
+  }
+
+  readonly fun ==(other: readonly StringIterator): Bool {
+    this.i == other.i
   }
 }

--- a/src/runtime/prelude/stdlib/filesystem/Path.sk
+++ b/src/runtime/prelude/stdlib/filesystem/Path.sk
@@ -43,12 +43,15 @@ fun isNormalized(path: String): Bool {
 // trimTrailingSeparators("") == ""
 fun trimTrailingSeparators(path: String): String {
   if (path == rootDirectory) {
-    path;
-  } else if (path.endsWith(separator)) {
-    trimTrailingSeparators(path.sub(0, path.length() - 1));
+    path
   } else {
-    path;
-  };
+    i = path.getEndIter();
+    while (i.prev() == Some('/')) {
+      void
+    };
+    _ = i.next();
+    path.getIter().substring(i)
+  }
 }
 
 // Returns the directory name of a path.

--- a/src/runtime/prelude/stdlib/int/UInt8.sk
+++ b/src/runtime/prelude/stdlib/int/UInt8.sk
@@ -13,5 +13,6 @@ value class UInt8 private (private value: Int8) uses Integral {
     UInt8(Int8::truncate(n))
   }
   const min: UInt8 = UInt8::truncate(0);
+  const zero: UInt8 = UInt8::truncate(0);
   const max: UInt8 = UInt8::truncate(0xFF);
 }

--- a/src/runtime/prelude/stdlib/other/StringIterator.sk
+++ b/src/runtime/prelude/stdlib/other/StringIterator.sk
@@ -1,0 +1,100 @@
+module String;
+
+extension mutable class StringIterator {
+  mutable fun forward(n: Int): mutable StringIterator {
+    for (_ in Range(0, n)) _ = this.next();
+    this
+  }
+
+  mutable fun rewind(n: Int): mutable StringIterator {
+    for (_ in Range(0, n)) _ = this.prev();
+    this
+  }
+
+  mutable fun takeString(n: Int = Int::max): String {
+    String::fromChars(Array::createFromIterator(this.take(n)));
+  }
+
+  mutable fun takeUntil(end: readonly StringIterator): String {
+    String::fromGenerator(() -> {
+      while (this < end) {
+        yield this.next().fromSome()
+      }
+    })
+  }
+
+  readonly fun compare(other: readonly StringIterator): Order {
+    for (i in this.clone().zipLongest(other.clone())) {
+      cmp = i.i0.compare(i.i1);
+      if (!(cmp is EQ())) return cmp;
+    } else {
+      EQ()
+    }
+  }
+
+  // Returns true if the iterator starts with the given prefix.  If the prefix
+  // matches then the iterator is moved forward to the end of the match
+  // otherwise it is unchanged.
+  mutable fun startsWith(other: readonly StringIterator): Bool {
+    i = this.clone();
+    for (ch in other.clone()) {
+      i.next() match {
+      | Some(ch2) if (ch != ch2) -> return false
+      | Some _ -> void
+      | None() -> return return false
+      }
+    };
+    this.assign(i);
+    true
+  }
+
+  mutable fun search(pattern: String): Bool {
+    if (pattern.length() == 1) {
+      exp = pattern.getIter().next().fromSome();
+      loop {
+        this.current() match {
+        | None() -> break false
+        | Some(c) if (c == exp) -> break true
+        | Some(_) -> _ = this.next()
+        }
+      }
+    } else {
+      while (!this.atEnd()) {
+        if (this.clone().startsWith(pattern.getIter())) break true;
+        _ = this.next();
+      } else {
+        false
+      }
+    }
+  }
+
+  mutable fun rsearch(pattern: String): Bool {
+    if (pattern.isEmpty()) {
+      true
+    } else if (pattern.length() == 1) {
+      exp = pattern.getIter().next().fromSome();
+      loop {
+        this.prev() match {
+        | None() -> break false
+        | Some(c) if (c == exp) -> break true
+        | Some(_) -> void
+        }
+      }
+    } else {
+      while (this.prev().isSome()) {
+        if (this.clone().startsWith(pattern.getIter())) break true
+      } else {
+        false
+      }
+    }
+  }
+
+  mutable fun rfind(p: Char -> Bool): ?Char {
+    loop {
+      this.prev() match {
+      | Some(x) -> if (p(x)) break Some(x)
+      | None() -> break None()
+      }
+    }
+  }
+}

--- a/src/runtime/prelude/stdlib/other/StringIterator.sk
+++ b/src/runtime/prelude/stdlib/other/StringIterator.sk
@@ -11,16 +11,17 @@ extension mutable class StringIterator {
     this
   }
 
-  mutable fun takeString(n: Int = Int::max): String {
+  mutable fun collectString(n: Int = Int::max): String {
     String::fromChars(Array::createFromIterator(this.take(n)));
   }
 
-  mutable fun takeUntil(end: readonly StringIterator): String {
-    String::fromGenerator(() -> {
+  mutable fun slice(end: readonly StringIterator): String {
+    gen: () -> mutable Iterator<Char> = () -> {
       while (this < end) {
         yield this.next().fromSome()
       }
-    })
+    };
+    String::fromChars(Array::createFromIterator(gen()))
   }
 
   readonly fun compare(other: readonly StringIterator): Order {
@@ -68,7 +69,7 @@ extension mutable class StringIterator {
     }
   }
 
-  mutable fun rsearch(pattern: String): Bool {
+  mutable fun reverseSearch(pattern: String): Bool {
     if (pattern.isEmpty()) {
       true
     } else if (pattern.length() == 1) {

--- a/src/runtime/prelude/stdlib/parsing/TextRange.sk
+++ b/src/runtime/prelude/stdlib/parsing/TextRange.sk
@@ -66,13 +66,13 @@ fun contentFromLines(tr: TextRange, lines: Vector<String>): String {
     line
       .getIter()
       .forward(tr.start.column())
-      .takeString(tr.end.column() - tr.start.column())
+      .collectString(tr.end.column() - tr.start.column())
   } else {
     gen: () -> mutable Iterator<String> = () -> {
       yield lines[tr.start.line()]
         .getIter()
         .forward(tr.start.column())
-        .takeString();
+        .collectString();
 
       for (i in Range(tr.start.line() + 1, tr.end.line())) {
         yield lines[i];

--- a/src/runtime/prelude/stdlib/parsing/TextRange.sk
+++ b/src/runtime/prelude/stdlib/parsing/TextRange.sk
@@ -59,26 +59,29 @@ fun empty(position: Position): TextRange {
 }
 
 fun contentFromLines(tr: TextRange, lines: Vector<String>): String {
-  result = "";
-  for (i in Range(0, tr.end.line() - tr.start.line() + 1)) {
-    index = tr.start.line() + i;
-    line = lines[index];
-    startColumn = if (index == tr.start.line()) {
-      tr.start.column();
-    } else {
-      0;
+  invariant(tr.end >= tr.start, "content end cannot be before content start");
+
+  if (tr.start.line() == tr.end.line()) {
+    line = lines[tr.start.line()];
+    line
+      .getIter()
+      .forward(tr.start.column())
+      .takeString(tr.end.column() - tr.start.column())
+  } else {
+    gen: () -> mutable Iterator<String> = () -> {
+      yield lines[tr.start.line()]
+        .getIter()
+        .forward(tr.start.column())
+        .takeString();
+
+      for (i in Range(tr.start.line() + 1, tr.end.line())) {
+        yield lines[i];
+      };
+
+      yield lines[tr.end.line()].take(tr.end.column());
     };
-    endColumn = if (index == tr.end.line()) {
-      tr.end.column();
-    } else {
-      line.length();
-    };
-    if (index > tr.start.line()) {
-      !result = result + Chars.lineFeed.toString();
-    };
-    !result = result + line.sub(startColumn, endColumn - startColumn);
-  };
-  result
+    gen().collect(Array).join(Chars.lineFeed.toString())
+  }
 }
 
 fun createEndOfLines(lines: Vector<String>): Position {

--- a/src/runtime/prelude/stdlib/serialization/JSON.sk
+++ b/src/runtime/prelude/stdlib/serialization/JSON.sk
@@ -121,7 +121,7 @@ private fun charToString(ch: Char): .String {
 }
 
 private fun writeStringValue(write: .String -> void, s: .String): void {
-  target = (s.search(0, requiresEscape)) match {
+  target = (s.search(requiresEscape)) match {
   | None() -> s
   | Some _ ->
     strings = mutable Vector<.String>[];

--- a/src/tools/CodeModTemplate.sk
+++ b/src/tools/CodeModTemplate.sk
@@ -22,8 +22,7 @@ mutable class MatchData{
   mutable fun transformTree(tree: P.ParseTree): ?P.ParseTree {
     tree match {
     | a @ P.TokenTree _ if (a.token.value.endsWith(kVarTokenPrefix)) ->
-      var = a.token.value.sub(
-        0,
+      var = a.token.value.take(
         a.token.value.length() - kVarTokenPrefix.length(),
       );
       Some(this.vars[var])
@@ -52,7 +51,7 @@ mutable class MatchData{
         name => P.TokenTree{token => tok @ Token.Token{value}},
       } if (value.endsWith(kVarTokenPrefix)) ->
         !replacedOne = true;
-        var = value.sub(0, value.length() - kVarTokenPrefix.length());
+        var = value.take(value.length() - kVarTokenPrefix.length());
         for (f in this.nameListVars[var].values()) {
           if (!args.isEmpty()) {
             seps.push(
@@ -200,7 +199,7 @@ class ParseTreeTemplate private {tree: P.ParseTree} {
       | P.NamedArgumentTree{
         name => P.TokenTree{token => Token.Token{value}},
       } if (value.endsWith(kVarTokenPrefix)) ->
-        !var = value.sub(0, value.length() - kVarTokenPrefix.length());
+        !var = value.take(value.length() - kVarTokenPrefix.length());
         true
       | _ -> false
       }
@@ -239,8 +238,7 @@ class ParseTreeTemplate private {tree: P.ParseTree} {
   ): Bool {
     (template, code) match {
     | (a @ P.TokenTree _, b @ _) if (a.token.value.endsWith(kVarTokenPrefix)) ->
-      var = a.token.value.sub(
-        0,
+      var = a.token.value.take(
         a.token.value.length() - kVarTokenPrefix.length(),
       );
       if (m.vars.maybeSet(var, b)) {

--- a/src/tools/CodeModTransform.sk
+++ b/src/tools/CodeModTransform.sk
@@ -383,7 +383,7 @@ class MainStringToVoidCodeMod() extends P.CodeMod {
               Array[
                 tokenTree with {
                   token => token with {
-                    value => value.sub(0, value.length() - 3) + "\"",
+                    value => value.take(value.length() - 3) + "\"",
                   },
                 },
               ],

--- a/src/tools/grammar.sk
+++ b/src/tools/grammar.sk
@@ -24,7 +24,7 @@ fun main(): void {
 fun isRuleStart(comment: Comment): Bool {
   comment.kind == Token.LineComment() &&
     comment.value.endsWith(":\n") &&
-    comment.value.get(comment.value.length() - 3) != ' ' &&
+    !comment.value.endsWith(" :\n") &&
     comment.value.startsWith("// ")
 }
 
@@ -33,7 +33,7 @@ fun isRuleContinuation(comment: Comment): Bool {
 }
 
 fun printComment(comment: Comment): void {
-  print_raw(comment.value.substring(3))
+  print_raw(comment.value.getIter().forward(3).takeString())
 }
 
 fun reportError<T>(message: String): T {
@@ -80,7 +80,10 @@ mutable class Extractor{
   }
 
   mutable fun addRule(comment: Comment): mutable Rule {
-    ruleName = comment.value.sub(3, comment.value.length() - 5);
+    ruleName = comment.value
+      .getIter()
+      .forward(3)
+      .takeUntil(comment.value.getEndIter().rewind(2));
     printComment(comment);
     if (this.rules.containsKey(ruleName)) {
       reportError("Duplicate rule: " + ruleName)
@@ -93,7 +96,12 @@ mutable class Extractor{
 
   mutable fun continueRule(comment: Comment, rule: mutable Rule): void {
     printComment(comment);
-    rule.add(comment.value.sub(3, comment.value.length() - 4))
+    rule.add(
+      comment.value
+        .getIter()
+        .forward(3)
+        .takeUntil(comment.value.getEndIter().rewind(1)),
+    )
   }
 
   mutable fun endRule(rule: mutable Rule): void {

--- a/src/tools/grammar.sk
+++ b/src/tools/grammar.sk
@@ -33,7 +33,7 @@ fun isRuleContinuation(comment: Comment): Bool {
 }
 
 fun printComment(comment: Comment): void {
-  print_raw(comment.value.getIter().forward(3).takeString())
+  print_raw(comment.value.getIter().forward(3).collectString())
 }
 
 fun reportError<T>(message: String): T {
@@ -83,7 +83,7 @@ mutable class Extractor{
     ruleName = comment.value
       .getIter()
       .forward(3)
-      .takeUntil(comment.value.getEndIter().rewind(2));
+      .slice(comment.value.getEndIter().rewind(2));
     printComment(comment);
     if (this.rules.containsKey(ruleName)) {
       reportError("Duplicate rule: " + ruleName)
@@ -100,7 +100,7 @@ mutable class Extractor{
       comment.value
         .getIter()
         .forward(3)
-        .takeUntil(comment.value.getEndIter().rewind(1)),
+        .slice(comment.value.getEndIter().rewind(1)),
     )
   }
 

--- a/src/tools/printer/printer.sk
+++ b/src/tools/printer/printer.sk
@@ -409,12 +409,12 @@ fun printComment(comment: Token.Comment): Doc {
             _ = pos.next();
             !starIndex = starIndex + 1
           | Some('*') ->
-            break " " + line.getIter().forward(starIndex).takeString()
-          | _ -> break line.getIter().forward(index).takeString()
+            break " " + line.getIter().forward(starIndex).collectString()
+          | _ -> break line.getIter().forward(index).collectString()
           }
         }
       } else {
-        line.getIter().forward(index).takeString()
+        line.getIter().forward(index).collectString()
       }
     } else {
       line

--- a/src/tools/printer/printer.sk
+++ b/src/tools/printer/printer.sk
@@ -408,12 +408,13 @@ fun printComment(comment: Token.Comment): Doc {
           | Some('\t') ->
             _ = pos.next();
             !starIndex = starIndex + 1
-          | Some('*') -> break " " + line.substring(starIndex)
-          | _ -> break line.substring(index)
+          | Some('*') ->
+            break " " + line.getIter().forward(starIndex).takeString()
+          | _ -> break line.getIter().forward(index).takeString()
           }
         }
       } else {
-        line.substring(index)
+        line.getIter().forward(index).takeString()
       }
     } else {
       line

--- a/src/tools/skipDocgen.sk
+++ b/src/tools/skipDocgen.sk
@@ -457,13 +457,15 @@ fun removeLeadingStar(line: String): String {
 }
 
 fun lowercaseFirst(str: String): String {
-  String::fromGenerator(() -> {
-    i = str.getIter();
-    i.next() match {
-    | Some(c) ->
-      yield c.uncapitalize();
-      for (ch in i) yield ch
-    | None() -> void
-    };
-  })
+  String::fromIterator(
+    (() -> {
+      i = str.getIter();
+      i.next() match {
+      | Some(c) ->
+        yield c.uncapitalize();
+        for (ch in i) yield ch
+      | None() -> void
+      };
+    })(),
+  )
 }

--- a/src/tools/skipDocgen.sk
+++ b/src/tools/skipDocgen.sk
@@ -457,15 +457,13 @@ fun removeLeadingStar(line: String): String {
 }
 
 fun lowercaseFirst(str: String): String {
-  if (str == "") {
-    ""
-  } else {
-    first = str[0];
-    firstLowerCase = if (first >= 'A' || first <= 'Z') {
-      Char::fromCode(first.code() + 32)
-    } else {
-      first
+  String::fromGenerator(() -> {
+    i = str.getIter();
+    i.next() match {
+    | Some(c) ->
+      yield c.uncapitalize();
+      for (ch in i) yield ch
+    | None() -> void
     };
-    firstLowerCase.toString() + str.substring(1)
-  }
+  })
 }

--- a/src/tools/skipDocgen.sk
+++ b/src/tools/skipDocgen.sk
@@ -457,15 +457,14 @@ fun removeLeadingStar(line: String): String {
 }
 
 fun lowercaseFirst(str: String): String {
-  String::fromIterator(
-    (() -> {
-      i = str.getIter();
-      i.next() match {
-      | Some(c) ->
-        yield c.uncapitalize();
-        for (ch in i) yield ch
-      | None() -> void
-      };
-    })(),
-  )
+  gen: () -> mutable Iterator<Char> = () -> {
+    i = str.getIter();
+    i.next() match {
+    | Some(c) ->
+      yield c.uncapitalize();
+      for (ch in i) yield ch
+    | None() -> void
+    };
+  };
+  String::fromChars(Array::createFromIterator(gen()))
 }

--- a/src/utils/skipError.sk
+++ b/src/utils/skipError.sk
@@ -257,7 +257,7 @@ fun getContextOfRange(range: TextRange, fileContents: String): String {
       } else {
         // Do not display chevrons under leading spaces
         line_length = line_contents.length();
-        firstNonSpaceColumnOpt = line_contents.search(0, ch ~> ch != ' ');
+        firstNonSpaceColumnOpt = line_contents.search(ch ~> ch != ' ');
         chevron_start = firstNonSpaceColumnOpt match {
         | None() ->
           if (start.line() == end.line()) {
@@ -265,7 +265,11 @@ fun getContextOfRange(range: TextRange, fileContents: String): String {
           } else {
             line_length;
           }
-        | Some(firstNonSpaceColumn) -> max(start.column(), firstNonSpaceColumn)
+        | Some(firstNonSpaceColumn) ->
+          max(
+            start.column(),
+            line_contents.getIter().substring(firstNonSpaceColumn).length(),
+          )
         };
         chevron_length = if (start.line() == end.line()) {
           max(start.column() + 1, end.column()) - chevron_start;

--- a/tests/runtime/js/lib/string.js
+++ b/tests/runtime/js/lib/string.js
@@ -225,17 +225,20 @@ module.exports = function(sk) {
         return this.__value;
       },
       'sub': function(start, len) {
-        start = sk.__.intToNumber(start);
-        len = sk.__.intToNumber(len);
+        start = sk.__.intToNumber(start.i);
+        var end = start + sk.__.intToNumber(len);
         const this_len = lengthOfString(this);
-        if(start < 0 || len < 0 || (start + len) > this_len) {
-          throwOutOfBounds(start + len);
+        if (start < 0) {
+          start = 0;
         }
-        if (start === 0 && len === this_len) {
+        if (end > this_len) {
+          end = this_len;
+        }
+        if (start === 0 && end === this_len) {
           return this;
         }
         const startIndex = indexOfChar(this.__value, getHasCombiningChars(this), start);
-        const endIndex = indexOfChar(this.__value, getHasCombiningChars(this), start + len);
+        const endIndex = indexOfChar(this.__value, getHasCombiningChars(this), end);
         return new String_(this.__value.substring(startIndex, endIndex), len !== (endIndex - startIndex));
       },
       'get': function(index) {

--- a/tests/runtime/native/include/skip/String-extc.h
+++ b/tests/runtime/native/include/skip/String-extc.h
@@ -46,6 +46,7 @@ extern SkipString SKIP_String_StringIterator__substring(
     SkipRObj* end);
 extern SkipInt SKIP_String_StringIterator__rawCurrent(SkipRObj* i);
 extern SkipInt SKIP_String_StringIterator__rawNext(SkipRObj* i);
+extern SkipInt SKIP_String_StringIterator__rawPrev(SkipRObj* i);
 extern void SKIP_String_StringIterator__rawDrop(SkipRObj* i, SkipInt n);
 extern SkipInt SKIP_String__length(SkipString s);
 

--- a/tests/runtime/native/src/String.cpp
+++ b/tests/runtime/native/src/String.cpp
@@ -475,6 +475,17 @@ struct StringIterator final : RObj {
     return rawCurrentImpl(m_byteOffset);
   }
 
+  int64_t rawPrev() {
+    if (m_byteOffset == 0) {
+      return -1;
+    }
+    UChar32 ch = 0;
+    int32_t offset = m_byteOffset;
+    U8_PREV(m_string.unsafeData(), 0, offset, ch);
+    m_byteOffset = offset;
+    return ch;
+  }
+
   void rawDrop(int64_t n) {
     if (n < 0) {
       SKIP_throwInvariantViolation(
@@ -697,6 +708,10 @@ SkipInt SKIP_String_StringIterator__rawCurrent(RObj* i) {
 
 SkipInt SKIP_String_StringIterator__rawNext(RObj* i) {
   return i->cast<StringIterator>().rawNext();
+}
+
+SkipInt SKIP_String_StringIterator__rawPrev(RObj* i) {
+  return i->cast<StringIterator>().rawPrev();
 }
 
 void SKIP_String_StringIterator__rawDrop(RObj* i, SkipInt n) {

--- a/tests/runtime/prelude/core/language/Iterator.sk
+++ b/tests/runtime/prelude/core/language/Iterator.sk
@@ -131,6 +131,20 @@ mutable base class .Iterator<+T> {
     mutable ZipIterator(this, other)
   }
 
+  // Returns a new iterator representing the tuples of the ith elements of this
+  // and the other iterator.  Unlike zip(), zipLongest() continues until both
+  // iterators are exhausted.
+  overridable mutable fun zipLongest<U>(
+    other: mutable Iterator<U>,
+  ): mutable Iterator<(?T, ?U)> {
+    loop {
+      (this.next(), other.next()) match {
+      | (None(), None()) -> break void
+      | i @ _ -> yield i
+      }
+    }
+  }
+
   // Returns a new iterator representing the results of calling the selection
   // function with tuples of the ith elements of this and the other iterator.
   overridable mutable fun zipWith<U, V>(
@@ -183,14 +197,11 @@ mutable base class .Iterator<+T> {
   // Returns Some(x) for the first item in this iterator that matches
   // the predicate, or None() if no items match.
   overridable mutable fun find(p: T -> Bool): ?T {
-    flag = true;
-    do
+    loop {
       this.next() match {
       | Some(x) -> if (p(x)) break Some(x)
-      | None() -> !flag = false
+      | None() -> break None()
       }
-     while (flag) else {
-      None()
     }
   }
 
@@ -290,7 +301,7 @@ mutable class TakeIterator<+T>(
   private mutable n: Int,
 ) extends Iterator<T> {
   readonly fun sizeHint(): ?Int {
-    this.base.sizeHint().map(sizeHint -> min(0, sizeHint - this.n))
+    this.base.sizeHint().map(sizeHint -> max(0, sizeHint - this.n))
   }
 
   mutable fun next(): ?T {

--- a/tests/runtime/prelude/core/primitives/Int.sk
+++ b/tests/runtime/prelude/core/primitives/Int.sk
@@ -247,6 +247,12 @@ native value class Int uses Number, Integral {
     });
   }
 
+  fun toStringHex(): String {
+    String::tabulate(16, i ~> {
+      Chars.intToHexDigit(this.ushr((15 - i) * 4).and(0xF))
+    })
+  }
+
   fun toString(): String {
     this.toStringImpl()
   }

--- a/tests/runtime/prelude/core/primitives/String.sk
+++ b/tests/runtime/prelude/core/primitives/String.sk
@@ -15,9 +15,9 @@ native class .String uses Hashable, Show, Orderable {
   @may_alloc
   native static fun fromUtf8(bytes: readonly Array<UInt8>): String;
 
-  // Careful, this is O(n) (because of utf8)
-  @cpp_runtime
-  native private fun unsafe_get(x: Int): Char;
+  static fun fromGenerator(gen: () -> mutable Iterator<Char>): String {
+    String::fromChars(Array::createFromIterator(gen()))
+  }
 
   @cpp_runtime
   native fun length(): Int;
@@ -28,86 +28,62 @@ native class .String uses Hashable, Show, Orderable {
   @cpp_runtime
   native private fun compare_raw(other: String): Int;
 
-  fun sub(start: Int, len: Int): String {
-    this_len = this.length();
-    if (start == 0 && len == this_len) {
-      this
-    } else {
-      if (start < 0 || len < 0 || (start + len).ugt(this_len)) {
-        throwOutOfBounds()
-      };
+  fun take(len: Int): String {
+    this.getIter().takeString(len)
+  }
 
-      // We don't want to use unsafe_get because it is O(n)
-      subString = mutable Vector[];
-      iter = this.getIter().drop(start);
-      for (_ in Range(0, len)) {
-        subString.push(iter.next().fromSome())
-      };
-      static::fromChars(freeze(subString.toArray()))
-    }
+  fun sub(start: readonly StringIterator, len: Int): String {
+    start.clone().takeString(len)
   }
 
   fun inspect(): Inspect {
     InspectString(this)
   }
 
-  fun substring(start: Int): String {
-    this.sub(start, this.length() - start)
+  fun substring(start: readonly StringIterator): String {
+    start.substring(this.getEndIter())
   }
 
-  private static fun isPrefix(
-    it1: mutable StringIterator,
-    it2: mutable StringIterator,
-  ): Bool {
-    it1.next() match {
-    | None() -> true
-    | Some(c1) ->
-      it2.next() match {
-      | Some(c2) if (c1 == c2) -> static::isPrefix(it1, it2)
-      | _ -> false
+  frozen fun startsWith(prefix: String): Bool {
+    this.getIter().clone().startsWith(prefix.getIter())
+  }
+
+  frozen fun endsWith(suffix: String): Bool {
+    iThis = this.getEndIter();
+    iSuffix = suffix.getEndIter();
+    loop {
+      (iThis.prev(), iSuffix.prev()) match {
+      | (_, None()) -> break true
+      | (None(), _) -> break false
+      | (Some(a), Some(b)) if (a != b) -> break false
+      | _ -> void
       }
     }
   }
 
-  frozen fun startsWith(prefix: String): Bool {
-    mySize = this.length();
-    prefixSize = prefix.length();
-
-    mySize >= prefixSize && static::isPrefix(prefix.getIter(), this.getIter())
-  }
-
-  frozen fun endsWith(suffix: String): Bool {
-    mySize = this.length();
-    suffixSize = suffix.length();
-
-    mySize >= suffixSize &&
-      static::isPrefix(
-        suffix.getIter(),
-        this.getIter().drop(mySize - suffixSize),
-      )
-  }
-
   fun stripPrefix(prefix: String): String {
-    if (this.startsWith(prefix)) {
-      this.substring(prefix.length())
+    i = this.getIter();
+    if (i.startsWith(prefix.getIter())) {
+      i.substring(this.getEndIter())
     } else {
       this
     }
   }
 
   fun stripSuffix(suffix: String): String {
-    if (this.endsWith(suffix)) {
-      this.sub(0, this.length() - suffix.length())
-    } else {
-      this
+    i = this.getEndIter();
+    j = suffix.getEndIter();
+    loop {
+      (i.prev(), j.prev()) match {
+      | (None(), None()) -> break ""
+      | (_, None()) ->
+        _ = i.next();
+        break this.getIter().substring(i)
+      | (None(), _) -> break this
+      | (Some(a), Some(b)) if (a != b) -> break this
+      | _ -> void
+      };
     }
-  }
-
-  fun get(x: Int): Char {
-    if (x.uge(this.length())) {
-      throwOutOfBounds()
-    };
-    this.unsafe_get(x)
   }
 
   fun +<T: readonly Show>(s: T): String {
@@ -119,13 +95,13 @@ native class .String uses Hashable, Show, Orderable {
   }
 
   fun repeat(count: Int): String {
-    if (count <= 0) {
-      ""
-    } else {
-      String::tabulate(count * this.length(), i -> {
-        this[i % this.length()]
-      })
-    }
+    String::fromGenerator(() -> {
+      for (_ in Range(0, count)) {
+        for (c in this) {
+          yield c;
+        }
+      }
+    })
   }
 
   @cpp_runtime
@@ -143,18 +119,6 @@ native class .String uses Hashable, Show, Orderable {
       !result = f(result, ch)
     });
     result;
-  }
-
-  private fun foldlImpl<Taccum>(
-    f: (Taccum, Char) -> Taccum,
-    accum: Taccum,
-    offset: Int,
-  ): Taccum {
-    if (offset >= this.length()) {
-      accum
-    } else {
-      this.foldlImpl(f, f(accum, this[offset]), offset + 1)
-    }
   }
 
   fun toIntOption(): ?Int {
@@ -248,20 +212,18 @@ native class .String uses Hashable, Show, Orderable {
   }
 
   fun trimLeft(): String {
-    offset = this.search(0, ch ~> !isWhitespace(ch));
-    if (offset.isSome()) {
-      this.substring(offset.fromSome())
-    } else {
-      ""
+    this.search(ch ~> !isWhitespace(ch)) match {
+    | Some(i) -> i.substring(this.getEndIter())
+    | None() -> ""
     }
   }
 
   fun trimRight(): String {
-    offset = this.rsearch(this.length() - 1, ch ~> !isWhitespace(ch));
-    if (offset.isSome()) {
-      this.sub(0, offset.fromSome() + 1)
-    } else {
-      ""
+    this.rsearch(ch ~> !isWhitespace(ch)) match {
+    | Some(i) ->
+      _ = i.next();
+      this.getIter().substring(i)
+    | None() -> ""
     }
   }
 
@@ -269,113 +231,45 @@ native class .String uses Hashable, Show, Orderable {
     this.trimLeft().trimRight()
   }
 
-  fun search(offset: Int, f: Char -> Bool): ?Int {
-    if (offset.uge(this.length())) {
-      None()
-    } else if (f(this.unsafe_get(offset))) {
-      Some(offset)
-    } else {
-      this.search(offset + 1, f)
-    }
+  // Finds the given pattern in the string, starting from 'from'
+  fun search(f: Char -> Bool): ?mutable StringIterator {
+    i = this.getIter();
+    i.find(f).map(_ -> {
+      _ = i.prev();
+      i
+    })
   }
 
-  fun searchIndex(offset: Int, f: Char -> Bool): Int {
-    if (offset.uge(this.length())) {
-      -1
-    } else if (f(this.unsafe_get(offset))) {
-      offset
-    } else {
-      this.searchIndex(offset + 1, f)
-    }
-  }
-
-  fun rsearch(offset: Int, f: Char -> Bool): ?Int {
-    if (offset.uge(this.length())) {
-      None()
-    } else if (f(this.unsafe_get(offset))) {
-      Some(offset)
-    } else {
-      this.rsearch(offset - 1, f)
-    }
+  fun rsearch(f: Char -> Bool): ?mutable StringIterator {
+    i = this.getEndIter();
+    i.rfind(f).map(_ -> i)
   }
 
   fun chars(): Vector<Char> {
     this.getIter().collect(Vector)
   }
 
-  private static fun iterStartsWith(
-    value: readonly StringIterator,
-    prefix: readonly StringIterator,
-  ): Bool {
-    testValue = value.clone();
-    testPrefix = prefix.clone();
-    matched = false;
-    while ({
-      (testPrefix.next(), testValue.next()) match {
-      | (None(), _) ->
-        !matched = true;
-        false
-      | (Some(chPrefix), Some(chCurrent)) if (chPrefix == chCurrent) -> true
-      | _ -> false
-      };
-    }) void;
-    matched;
-  }
-
-  private static fun find(
-    value: readonly StringIterator,
-    substring: readonly StringIterator,
-  ): mutable StringIterator {
-    testValue = value.clone();
-    while (
-      !testValue.atEnd() &&
-      !static::iterStartsWith(testValue, substring)
-    ) _ = testValue.next();
-    testValue
-  }
-
-  private fun index(substring: String, offset: Int): ?Int {
-    if (offset > this.length() - substring.length()) {
-      None()
-    } else if (this.sub(offset, substring.length()) == substring) {
-      Some(offset)
-    } else {
-      this.index(substring, offset + 1)
-    }
-  }
-
   fun splitLast(substring: String): (String, String) {
-    a = this.length();
-    b = substring.length();
-    (a, b) match {
-    | (0, _) -> ("", "")
-    | (_, 0) -> (this, "")
-    | (_, 1) -> this.splitLastCharHelper(substring[0], a - 1)
-    | _ if (a < b) -> ("", this)
-    | _ -> this.splitLastHelper(substring, a - b)
+    i = this.getEndIter();
+    if (!i.rsearch(substring)) {
+      ("", this)
+    } else {
+      a = this.getIter().substring(i);
+      _ = i.drop(substring.length());
+      b = i.substring(this.getEndIter());
+      (a, b)
     }
   }
 
-  private fun splitLastCharHelper(ch: Char, offset: Int): (String, String) {
-    if (this.unsafe_get(offset) == ch) {
-      (this.sub(0, offset), this.substring(offset + 1))
-    } else if (offset > 0) {
-      this.splitLastCharHelper(ch, offset - 1)
+  fun splitFirst(substring: String): (String, String) {
+    i = this.getIter();
+    if (!i.search(substring)) {
+      (this, "")
     } else {
-      ("", this)
-    }
-  }
-
-  private fun splitLastHelper(
-    substring: String,
-    offset: Int,
-  ): (String, String) {
-    if (this.sub(offset, substring.length()) == substring) {
-      (this.sub(0, offset), this.substring(offset + substring.length()))
-    } else if (offset == 0) {
-      ("", this)
-    } else {
-      this.splitLastHelper(substring, offset - 1)
+      a = this.getIter().substring(i);
+      _ = i.drop(substring.length());
+      b = i.substring(this.getEndIter());
+      (a, b)
     }
   }
 
@@ -383,59 +277,46 @@ native class .String uses Hashable, Show, Orderable {
   native fun contains(search: String): Bool;
 
   fun replace(search: String, replacement: String): String {
-    if (search.length() == 0) {
-      this
-    } else {
-      res = this;
-      start = 0;
-      while ({
-        index_opt = res.index(search, start);
-        index_opt match {
-        | Some(index) ->
-          !start = index + replacement.length();
-          !res = String::tabulate(
-            res.length() - search.length() + replacement.length(),
-            i -> {
-              if (i < index) {
-                res[i]
-              } else if (i < index + replacement.length()) {
-                replacement[i - index]
-              } else {
-                res[i - replacement.length() + search.length()]
-              }
-            },
-          );
-          true
-        | None() -> false
-        }
-      }) void;
-      res
-    }
+    if (search.isEmpty()) {
+      return this;
+    };
+
+    String::fromGenerator(() -> {
+      i = this.getIter();
+      searchLength = search.length();
+      while (!i.atEnd()) {
+        start = i.clone();
+        if (!i.search(search)) {
+          !i = start;
+          break void;
+        };
+        for (c in start.substring(i)) yield c;
+        for (c in replacement) yield c;
+        _ = i.drop(searchLength);
+      };
+      for (c in i) yield c;
+    })
   }
 
-  fun split(delimiter: String): Vector<String> {
+  fun split(delimiter: String, maxCount: Int = Int::max): Vector<String> {
     delimiterLength = delimiter.length();
     if (delimiterLength == 0) {
       invariant_violation("String.split: cannot split with empty delimiter")
     } else if (this.isEmpty()) {
       Vector[""]
     } else {
-      vector = mutable Vector[];
-      current = this.getIter();
-      delimiterIter = delimiter.getIter();
-
-      while ({
-        end = static::find(current, delimiterIter);
-        vector.push(current.substring(end));
-        !current = end;
-        if (!current.atEnd()) {
-          _ = current.drop(delimiterLength);
-          true;
-        } else {
-          false;
+      gen: () -> mutable Iterator<String> = () -> {
+        start = this.getIter();
+        i = start.clone();
+        while (i.search(delimiter) && maxCount > 0) {
+          !maxCount = maxCount - 1;
+          yield start.substring(i);
+          _ = i.drop(delimiterLength);
+          !start = i.clone();
         };
-      }) void;
-      freeze(vector)
+        yield start.substring(this.getEndIter());
+      };
+      Vector::createFromIterator(gen());
     }
   }
 
@@ -444,34 +325,26 @@ native class .String uses Hashable, Show, Orderable {
   }
 
   fun padLeft(width: Int, chr: Char = ' '): String {
-    len = this.length();
-    if (len >= width) {
+    n = this.length();
+    if (width <= n) {
       this
     } else {
-      padCount = width - len;
-      String::tabulate(width, n -> {
-        if (n < padCount) {
-          chr
-        } else {
-          this[n - padCount]
-        }
+      String::fromGenerator(() -> {
+        for (_ in Range(0, width - n)) yield chr;
+        for (c in this) yield c;
       })
     }
   }
 
   fun padRight(width: Int, chr: Char = ' '): String {
-    len = this.length();
-    if (len >= width) {
-      this
-    } else {
-      String::tabulate(width, n -> {
-        if (n < len) {
-          this[n]
-        } else {
-          chr
-        }
-      })
-    }
+    String::fromGenerator(() -> {
+      count = 0;
+      for (c in this) {
+        !count = count + 1;
+        yield c;
+      };
+      for (_ in Range(count, width)) yield chr;
+    });
   }
 
   fun ==(other: String): Bool {
@@ -515,6 +388,10 @@ native class .String uses Hashable, Show, Orderable {
     StringIterator::make(this)
   }
 
+  fun getEndIter(): mutable StringIterator {
+    StringIterator::makeEnd(this)
+  }
+
   fun values(): mutable StringIterator {
     StringIterator::make(this)
   }
@@ -526,10 +403,7 @@ native class .String uses Hashable, Show, Orderable {
   @synonym("upcase")
   @synonym("uc")
   fun uppercase(): String {
-    chars = Array::fillBy(this.length(), index ->
-      this.unsafe_get(index).capitalize()
-    );
-    String::fromChars(chars)
+    String::fromChars(this.getIter().map(c -> c.capitalize()).collect(Array))
   }
 
   @synonym("toLowerCase")
@@ -539,38 +413,29 @@ native class .String uses Hashable, Show, Orderable {
   @synonym("downcase")
   @synonym("lc")
   fun lowercase(): String {
-    chars = Array::fillBy(this.length(), index ->
-      this.unsafe_get(index).uncapitalize()
-    );
-    String::fromChars(chars)
+    String::fromChars(this.getIter().map(c -> c.uncapitalize()).collect(Array))
   }
 
   fun uppercaseFirst(): String {
-    if (this.isEmpty()) {
-      this
-    } else {
-      first = this.unsafe_get(0);
-      first_capitalize = first.capitalize();
-      if (first == first_capitalize) {
-        this
-      } else {
-        `${first_capitalize}${this.substring(1)}`
-      }
-    }
+    String::fromGenerator(() -> {
+      i = this.getIter();
+      i.next() match {
+      | Some(ch) -> yield ch.capitalize()
+      | None() -> void
+      };
+      for (ch in i) yield ch;
+    });
   }
 
   fun lowercaseFirst(): String {
-    if (this.isEmpty()) {
-      this
-    } else {
-      first = this.unsafe_get(0);
-      first_uncapitalize = first.uncapitalize();
-      if (first == first_uncapitalize) {
-        this
-      } else {
-        `${first_uncapitalize}${this.substring(1)}`
-      }
-    }
+    String::fromGenerator(() -> {
+      i = this.getIter();
+      i.next() match {
+      | Some(ch) -> yield ch.uncapitalize()
+      | None() -> void
+      };
+      for (ch in i) yield ch;
+    });
   }
 }
 

--- a/tests/runtime/prelude/core/primitives/String.sk
+++ b/tests/runtime/prelude/core/primitives/String.sk
@@ -15,7 +15,7 @@ native class .String uses Hashable, Show, Orderable {
   @may_alloc
   native static fun fromUtf8(bytes: readonly Array<UInt8>): String;
 
-  static fun fromGenerator(gen: () -> mutable Iterator<Char>): String {
+  private static fun fromGenerator(gen: () -> mutable Iterator<Char>): String {
     String::fromChars(Array::createFromIterator(gen()))
   }
 
@@ -29,11 +29,11 @@ native class .String uses Hashable, Show, Orderable {
   native private fun compare_raw(other: String): Int;
 
   fun take(len: Int): String {
-    this.getIter().takeString(len)
+    this.getIter().collectString(len)
   }
 
   fun sub(start: readonly StringIterator, len: Int): String {
-    start.clone().takeString(len)
+    start.clone().collectString(len)
   }
 
   fun inspect(): Inspect {
@@ -219,7 +219,7 @@ native class .String uses Hashable, Show, Orderable {
   }
 
   fun trimRight(): String {
-    this.rsearch(ch ~> !isWhitespace(ch)) match {
+    this.searchRight(ch ~> !isWhitespace(ch)) match {
     | Some(i) ->
       _ = i.next();
       this.getIter().substring(i)
@@ -240,7 +240,7 @@ native class .String uses Hashable, Show, Orderable {
     })
   }
 
-  fun rsearch(f: Char -> Bool): ?mutable StringIterator {
+  fun searchRight(f: Char -> Bool): ?mutable StringIterator {
     i = this.getEndIter();
     i.rfind(f).map(_ -> i)
   }
@@ -251,7 +251,7 @@ native class .String uses Hashable, Show, Orderable {
 
   fun splitLast(substring: String): (String, String) {
     i = this.getEndIter();
-    if (!i.rsearch(substring)) {
+    if (!i.reverseSearch(substring)) {
       ("", this)
     } else {
       a = this.getIter().substring(i);

--- a/tests/runtime/prelude/native/StringIterator.sk
+++ b/tests/runtime/prelude/native/StringIterator.sk
@@ -18,8 +18,20 @@ mutable class StringIterator private (
     mutable StringIterator(s, 0)
   }
 
+  static fun makeEnd(s: String): mutable StringIterator {
+    mutable StringIterator(s, s.utf8().size())
+  }
+
   readonly fun clone(): mutable StringIterator {
     mutable StringIterator(this.s, this.i);
+  }
+
+  mutable fun assign(other: readonly StringIterator): void {
+    invariant(
+      this.s == other.s,
+      "Cannot assign from different string iterator",
+    );
+    this.!i = other.i;
   }
 
   private static fun charFromCodeOpt(code: Int): ?Char {
@@ -46,6 +58,10 @@ mutable class StringIterator private (
     static::charFromCodeOpt(this.rawNext());
   }
 
+  mutable fun prev(): ?Char {
+    static::charFromCodeOpt(this.rawPrev());
+  }
+
   mutable fun drop(n: Int): mutable StringIterator {
     this.rawDrop(n);
     this
@@ -59,5 +75,19 @@ mutable class StringIterator private (
   @cpp_runtime
   private mutable native fun rawNext(): Int;
   @cpp_runtime
+  private mutable native fun rawPrev(): Int;
+  @cpp_runtime
   private mutable native fun rawDrop(n: Int): void;
+
+  readonly fun <(other: readonly StringIterator): Bool {
+    this.i < other.i
+  }
+
+  readonly fun >(other: readonly StringIterator): Bool {
+    this.i > other.i
+  }
+
+  readonly fun ==(other: readonly StringIterator): Bool {
+    this.i == other.i
+  }
 }

--- a/tests/runtime/prelude/nonnative/String.sk
+++ b/tests/runtime/prelude/nonnative/String.sk
@@ -9,6 +9,9 @@ module String;
 
 extension class .String {
   native fun utf8(): IndexedSequence<UInt8>;
+
+  // This function is only defined for the non-native backend.  Don't use it.
+  native fun unsafe_get(x: Int): Char;
 }
 
 // This is only parameterized on T because changing that to UInt8 causes a

--- a/tests/runtime/prelude/nonnative/StringIterator.sk
+++ b/tests/runtime/prelude/nonnative/StringIterator.sk
@@ -78,14 +78,15 @@ mutable class StringIterator private (
       "Called StringIterator::substring with end before start",
     );
     i = this.clone();
-    String::fromGenerator(() -> {
+    gen: () -> mutable Iterator<Char> = () -> {
       while (i.i != end.i) {
         i.next() match {
         | Some(ch) -> yield ch
         | None() -> break void
         }
       }
-    })
+    };
+    String::fromChars(Array::createFromIterator(gen()))
   }
 
   readonly fun <(other: readonly StringIterator): Bool {

--- a/tests/runtime/prelude/nonnative/StringIterator.sk
+++ b/tests/runtime/prelude/nonnative/StringIterator.sk
@@ -16,8 +16,21 @@ mutable class StringIterator private (
     mutable StringIterator(s, 0, s.length())
   }
 
+  static fun makeEnd(s: String): mutable StringIterator {
+    len = s.length();
+    mutable StringIterator(s, len, len)
+  }
+
   readonly fun clone(): mutable StringIterator {
     mutable StringIterator(this.s, this.i, this.length);
+  }
+
+  mutable fun assign(other: readonly StringIterator): void {
+    invariant(
+      this.s == other.s,
+      "Cannot assign from different string iterator",
+    );
+    this.!i = other.i;
   }
 
   mutable fun drop(n: Int): mutable StringIterator {
@@ -34,7 +47,7 @@ mutable class StringIterator private (
     if (this.atEnd()) {
       None()
     } else {
-      Some(this.s.get(this.i));
+      Some(this.s.unsafe_get(this.i));
     }
   }
 
@@ -47,10 +60,43 @@ mutable class StringIterator private (
     if (result.isSome()) {
       this.!i = this.i + 1;
     };
-    result;
+    result
+  }
+
+  mutable fun prev(): ?Char {
+    if (this.i == 0) {
+      None()
+    } else {
+      this.!i = this.i - 1;
+      this.current()
+    }
   }
 
   readonly fun substring(end: readonly StringIterator): String {
-    this.s.sub(this.i, end.i - this.i);
+    invariant(
+      end.i >= this.i,
+      "Called StringIterator::substring with end before start",
+    );
+    i = this.clone();
+    String::fromGenerator(() -> {
+      while (i.i != end.i) {
+        i.next() match {
+        | Some(ch) -> yield ch
+        | None() -> break void
+        }
+      }
+    })
+  }
+
+  readonly fun <(other: readonly StringIterator): Bool {
+    this.i < other.i
+  }
+
+  readonly fun >(other: readonly StringIterator): Bool {
+    this.i > other.i
+  }
+
+  readonly fun ==(other: readonly StringIterator): Bool {
+    this.i == other.i
   }
 }

--- a/tests/runtime/prelude/stdlib/filesystem/Path.sk
+++ b/tests/runtime/prelude/stdlib/filesystem/Path.sk
@@ -43,12 +43,15 @@ fun isNormalized(path: String): Bool {
 // trimTrailingSeparators("") == ""
 fun trimTrailingSeparators(path: String): String {
   if (path == rootDirectory) {
-    path;
-  } else if (path.endsWith(separator)) {
-    trimTrailingSeparators(path.sub(0, path.length() - 1));
+    path
   } else {
-    path;
-  };
+    i = path.getEndIter();
+    while (i.prev() == Some('/')) {
+      void
+    };
+    _ = i.next();
+    path.getIter().substring(i)
+  }
 }
 
 // Returns the directory name of a path.

--- a/tests/runtime/prelude/stdlib/int/UInt8.sk
+++ b/tests/runtime/prelude/stdlib/int/UInt8.sk
@@ -13,5 +13,6 @@ value class UInt8 private (private value: Int8) uses Integral {
     UInt8(Int8::truncate(n))
   }
   const min: UInt8 = UInt8::truncate(0);
+  const zero: UInt8 = UInt8::truncate(0);
   const max: UInt8 = UInt8::truncate(0xFF);
 }

--- a/tests/runtime/prelude/stdlib/other/StringIterator.sk
+++ b/tests/runtime/prelude/stdlib/other/StringIterator.sk
@@ -1,0 +1,100 @@
+module String;
+
+extension mutable class StringIterator {
+  mutable fun forward(n: Int): mutable StringIterator {
+    for (_ in Range(0, n)) _ = this.next();
+    this
+  }
+
+  mutable fun rewind(n: Int): mutable StringIterator {
+    for (_ in Range(0, n)) _ = this.prev();
+    this
+  }
+
+  mutable fun takeString(n: Int = Int::max): String {
+    String::fromChars(Array::createFromIterator(this.take(n)));
+  }
+
+  mutable fun takeUntil(end: readonly StringIterator): String {
+    String::fromGenerator(() -> {
+      while (this < end) {
+        yield this.next().fromSome()
+      }
+    })
+  }
+
+  readonly fun compare(other: readonly StringIterator): Order {
+    for (i in this.clone().zipLongest(other.clone())) {
+      cmp = i.i0.compare(i.i1);
+      if (!(cmp is EQ())) return cmp;
+    } else {
+      EQ()
+    }
+  }
+
+  // Returns true if the iterator starts with the given prefix.  If the prefix
+  // matches then the iterator is moved forward to the end of the match
+  // otherwise it is unchanged.
+  mutable fun startsWith(other: readonly StringIterator): Bool {
+    i = this.clone();
+    for (ch in other.clone()) {
+      i.next() match {
+      | Some(ch2) if (ch != ch2) -> return false
+      | Some _ -> void
+      | None() -> return return false
+      }
+    };
+    this.assign(i);
+    true
+  }
+
+  mutable fun search(pattern: String): Bool {
+    if (pattern.length() == 1) {
+      exp = pattern.getIter().next().fromSome();
+      loop {
+        this.current() match {
+        | None() -> break false
+        | Some(c) if (c == exp) -> break true
+        | Some(_) -> _ = this.next()
+        }
+      }
+    } else {
+      while (!this.atEnd()) {
+        if (this.clone().startsWith(pattern.getIter())) break true;
+        _ = this.next();
+      } else {
+        false
+      }
+    }
+  }
+
+  mutable fun rsearch(pattern: String): Bool {
+    if (pattern.isEmpty()) {
+      true
+    } else if (pattern.length() == 1) {
+      exp = pattern.getIter().next().fromSome();
+      loop {
+        this.prev() match {
+        | None() -> break false
+        | Some(c) if (c == exp) -> break true
+        | Some(_) -> void
+        }
+      }
+    } else {
+      while (this.prev().isSome()) {
+        if (this.clone().startsWith(pattern.getIter())) break true
+      } else {
+        false
+      }
+    }
+  }
+
+  mutable fun rfind(p: Char -> Bool): ?Char {
+    loop {
+      this.prev() match {
+      | Some(x) -> if (p(x)) break Some(x)
+      | None() -> break None()
+      }
+    }
+  }
+}

--- a/tests/runtime/prelude/stdlib/other/StringIterator.sk
+++ b/tests/runtime/prelude/stdlib/other/StringIterator.sk
@@ -11,16 +11,17 @@ extension mutable class StringIterator {
     this
   }
 
-  mutable fun takeString(n: Int = Int::max): String {
+  mutable fun collectString(n: Int = Int::max): String {
     String::fromChars(Array::createFromIterator(this.take(n)));
   }
 
-  mutable fun takeUntil(end: readonly StringIterator): String {
-    String::fromGenerator(() -> {
+  mutable fun slice(end: readonly StringIterator): String {
+    gen: () -> mutable Iterator<Char> = () -> {
       while (this < end) {
         yield this.next().fromSome()
       }
-    })
+    };
+    String::fromChars(Array::createFromIterator(gen()))
   }
 
   readonly fun compare(other: readonly StringIterator): Order {
@@ -68,7 +69,7 @@ extension mutable class StringIterator {
     }
   }
 
-  mutable fun rsearch(pattern: String): Bool {
+  mutable fun reverseSearch(pattern: String): Bool {
     if (pattern.isEmpty()) {
       true
     } else if (pattern.length() == 1) {

--- a/tests/runtime/prelude/stdlib/parsing/TextRange.sk
+++ b/tests/runtime/prelude/stdlib/parsing/TextRange.sk
@@ -66,13 +66,13 @@ fun contentFromLines(tr: TextRange, lines: Vector<String>): String {
     line
       .getIter()
       .forward(tr.start.column())
-      .takeString(tr.end.column() - tr.start.column())
+      .collectString(tr.end.column() - tr.start.column())
   } else {
     gen: () -> mutable Iterator<String> = () -> {
       yield lines[tr.start.line()]
         .getIter()
         .forward(tr.start.column())
-        .takeString();
+        .collectString();
 
       for (i in Range(tr.start.line() + 1, tr.end.line())) {
         yield lines[i];

--- a/tests/runtime/prelude/stdlib/parsing/TextRange.sk
+++ b/tests/runtime/prelude/stdlib/parsing/TextRange.sk
@@ -59,26 +59,29 @@ fun empty(position: Position): TextRange {
 }
 
 fun contentFromLines(tr: TextRange, lines: Vector<String>): String {
-  result = "";
-  for (i in Range(0, tr.end.line() - tr.start.line() + 1)) {
-    index = tr.start.line() + i;
-    line = lines[index];
-    startColumn = if (index == tr.start.line()) {
-      tr.start.column();
-    } else {
-      0;
+  invariant(tr.end >= tr.start, "content end cannot be before content start");
+
+  if (tr.start.line() == tr.end.line()) {
+    line = lines[tr.start.line()];
+    line
+      .getIter()
+      .forward(tr.start.column())
+      .takeString(tr.end.column() - tr.start.column())
+  } else {
+    gen: () -> mutable Iterator<String> = () -> {
+      yield lines[tr.start.line()]
+        .getIter()
+        .forward(tr.start.column())
+        .takeString();
+
+      for (i in Range(tr.start.line() + 1, tr.end.line())) {
+        yield lines[i];
+      };
+
+      yield lines[tr.end.line()].take(tr.end.column());
     };
-    endColumn = if (index == tr.end.line()) {
-      tr.end.column();
-    } else {
-      line.length();
-    };
-    if (index > tr.start.line()) {
-      !result = result + Chars.lineFeed.toString();
-    };
-    !result = result + line.sub(startColumn, endColumn - startColumn);
-  };
-  result
+    gen().collect(Array).join(Chars.lineFeed.toString())
+  }
 }
 
 fun createEndOfLines(lines: Vector<String>): Position {

--- a/tests/runtime/prelude/stdlib/serialization/JSON.sk
+++ b/tests/runtime/prelude/stdlib/serialization/JSON.sk
@@ -121,7 +121,7 @@ private fun charToString(ch: Char): .String {
 }
 
 private fun writeStringValue(write: .String -> void, s: .String): void {
-  target = (s.search(0, requiresEscape)) match {
+  target = (s.search(requiresEscape)) match {
   | None() -> s
   | Some _ ->
     strings = mutable Vector<.String>[];

--- a/tests/src/frontend/runtime/nested_closure_capture.sk
+++ b/tests/src/frontend/runtime/nested_closure_capture.sk
@@ -1,7 +1,15 @@
 fun searcher(find: Char): (String ~> Int) {
   s ~> {
-    maybeIdx = s.search(0, c ~> c == find);
-    maybeIdx.fromSome()
+    i = s.getIter();
+    count = 0;
+    loop {
+      i.next() match {
+      | Some(ch) if (ch == find) -> break count
+      | Some _ -> void
+      | None() -> break -1
+      };
+      !count = count + 1;
+    }
   }
 }
 

--- a/tests/src/frontend/typechecking/invalid/invalid_conditional_use_3.exp_err
+++ b/tests/src/frontend/typechecking/invalid/invalid_conditional_use_3.exp_err
@@ -14,10 +14,10 @@ The type: C
    |           ^
 12 |   "" + c
 
-File "../../runtime/prelude/core/primitives/String.sk", line 113, characters 12-24:
+File "../../runtime/prelude/core/primitives/String.sk", line 89, characters 12-24:
 Is not a subtype of: readonly Show
-111 |   }
-112 |
-113 |   fun +<T: readonly Show>(s: T): String {
-    |            ^^^^^^^^^^^^^
-114 |     this.concat(s.toString())
+87 |   }
+88 |
+89 |   fun +<T: readonly Show>(s: T): String {
+   |            ^^^^^^^^^^^^^
+90 |     this.concat(s.toString())

--- a/tests/src/runtime/prelude/IntTest.sk
+++ b/tests/src/runtime/prelude/IntTest.sk
@@ -68,6 +68,15 @@ fun testToStringBinary(): void {
 }
 
 @test
+fun testToStringHex(): void {
+  assertEqual((0x0000000000000000).toStringHex(), "0000000000000000");
+  assertEqual((0x0123456789ABCDEF).toStringHex(), "0123456789abcdef");
+  assertEqual((0xFFFFFFFFFFFFFFFF).toStringHex(), "ffffffffffffffff");
+  assertEqual((0x8000000000000000).toStringHex(), "8000000000000000");
+  assertEqual((0x0000000000000001).toStringHex(), "0000000000000001");
+}
+
+@test
 fun testBits(): void {
   assertEqual(0.ctz(), 64);
   assertEqual(ctz(0), 64);

--- a/tests/src/runtime/prelude/PathTest.sk
+++ b/tests/src/runtime/prelude/PathTest.sk
@@ -197,3 +197,12 @@ fun testResolve(): void {
     };
   });
 }
+
+@test
+fun testTrimTrailingSeparators(): void {
+  assertEqual(Path.trimTrailingSeparators("path/"), "path");
+  assertEqual(Path.trimTrailingSeparators("path///"), "path");
+  assertEqual(Path.trimTrailingSeparators("/"), "/");
+  assertEqual(Path.trimTrailingSeparators("///"), "/");
+  assertEqual(Path.trimTrailingSeparators(""), "");
+}

--- a/tests/src/runtime/prelude/StringTest.sk
+++ b/tests/src/runtime/prelude/StringTest.sk
@@ -24,17 +24,17 @@ fun testExampleSplit(): void {
 @test
 fun testTakeString(): void {
   s = "abcde";
-  assertEqual(s.getIter().takeString(1), "a");
-  assertEqual(s.getIter().takeString(2), "ab");
-  assertEqual(s.getIter().takeString(5), "abcde");
-  assertEqual(s.getIter().takeString(6), "abcde");
+  assertEqual(s.getIter().collectString(1), "a");
+  assertEqual(s.getIter().collectString(2), "ab");
+  assertEqual(s.getIter().collectString(5), "abcde");
+  assertEqual(s.getIter().collectString(6), "abcde");
 
   i = s.getIter();
-  assertEqual(i.takeString(2), "ab");
-  assertEqual(i.takeString(2), "cd");
-  assertEqual(i.takeString(2), "e");
+  assertEqual(i.collectString(2), "ab");
+  assertEqual(i.collectString(2), "cd");
+  assertEqual(i.collectString(2), "e");
 
-  assertEqual("abcde".getIter().forward(1).takeString(), "bcde");
+  assertEqual("abcde".getIter().forward(1).collectString(), "bcde");
 }
 
 fun subHelp(s: String, n: Int, len: Int): String {
@@ -342,7 +342,7 @@ fun testSubstringLarge(): void {
 @test
 fun testTrim(): void {
   assertEqual("".trim(), "");
-  assertEqual("a".trimRight(), "a");
+  assertEqual("a".trim(), "a");
   assertEqual("  a  ".trim(), "a");
   // All the special characters
   assertEqual("\u0020".trim(), "");
@@ -519,13 +519,13 @@ fun testIterSearch(): void {
 fun testIterRSearch(): void {
   expectFind = (str, pat, exp) -> {
     i = str.getEndIter();
-    assertTrue(i.rsearch(pat));
+    assertTrue(i.reverseSearch(pat));
     assertEqual(String::fromChars(i.collect(Array)), exp);
   };
 
   expectNotFind = (str, pat) -> {
     i = str.getEndIter();
-    assertFalse(i.rsearch(pat));
+    assertFalse(i.reverseSearch(pat));
     assertEqual(String::fromChars(i.collect(Array)), str);
   };
 
@@ -549,8 +549,5 @@ fun testIterRSearch(): void {
 @test
 fun testTakeUntil(): void {
   x = "abcde";
-  assertEqual(
-    x.getIter().forward(1).takeUntil(x.getEndIter().rewind(1)),
-    "bcd",
-  );
+  assertEqual(x.getIter().forward(1).slice(x.getEndIter().rewind(1)), "bcd");
 }

--- a/tests/src/runtime/prelude/StringTest.sk
+++ b/tests/src/runtime/prelude/StringTest.sk
@@ -22,6 +22,37 @@ fun testExampleSplit(): void {
 }
 
 @test
+fun testTakeString(): void {
+  s = "abcde";
+  assertEqual(s.getIter().takeString(1), "a");
+  assertEqual(s.getIter().takeString(2), "ab");
+  assertEqual(s.getIter().takeString(5), "abcde");
+  assertEqual(s.getIter().takeString(6), "abcde");
+
+  i = s.getIter();
+  assertEqual(i.takeString(2), "ab");
+  assertEqual(i.takeString(2), "cd");
+  assertEqual(i.takeString(2), "e");
+
+  assertEqual("abcde".getIter().forward(1).takeString(), "bcde");
+}
+
+fun subHelp(s: String, n: Int, len: Int): String {
+  i = s.getIter();
+  _ = i.drop(n);
+  s.sub(i, len)
+}
+
+@test
+fun testSub(): void {
+  assertEqual(subHelp("abcd", 0, 3), "abc");
+  assertEqual(subHelp("abcd", 1, 3), "bcd");
+  assertEqual(subHelp("abcd", 2, 3), "cd");
+  assertEqual(subHelp("abcd", 3, 3), "d");
+  assertEqual(subHelp("abcd", 4, 3), "");
+}
+
+@test
 fun testSplit(): void {
   str = "a,b,c,d,e";
   items = mutable Vector[];
@@ -55,6 +86,13 @@ fun testSplit2(): void {
   for (i in Range(0, items.size())) {
     assertEqual(items.get(i), expected.get(i))
   };
+}
+
+@test
+fun testSplit3(): void {
+  str = "a,b,c,d,e";
+  items = str.split(",", 2);
+  assertEqual(items, Vector["a", "b", "c,d,e"]);
 }
 
 @test
@@ -149,6 +187,28 @@ fun testSplitLast(): void {
   assertTrue("abcdefghi".splitLast("hi") == ("abcdefg", ""));
   assertTrue("abcdefghi".splitLast("ab") == ("", "cdefghi"));
   assertTrue("abcdefghi".splitLast("gf") == ("", "abcdefghi"));
+
+  assertTrue("a/b/c/d".splitLast("/") == ("a/b/c", "d"));
+}
+
+@test
+fun testSplitFirst(): void {
+  assertTrue("".splitFirst("") == ("", ""));
+  assertTrue("".splitFirst("x") == ("", ""));
+  assertTrue("".splitFirst("xy") == ("", ""));
+
+  assertTrue("abcdefghi".splitFirst("") == ("", "abcdefghi"));
+  assertTrue("abcdefghi".splitFirst("f") == ("abcde", "ghi"));
+  assertTrue("abcdefghi".splitFirst("i") == ("abcdefgh", ""));
+  assertTrue("abcdefghi".splitFirst("a") == ("", "bcdefghi"));
+  assertTrue("abcdefghi".splitFirst("z") == ("abcdefghi", ""));
+
+  assertTrue("abcdefghi".splitFirst("fg") == ("abcde", "hi"));
+  assertTrue("abcdefghi".splitFirst("hi") == ("abcdefg", ""));
+  assertTrue("abcdefghi".splitFirst("ab") == ("", "cdefghi"));
+  assertTrue("abcdefghi".splitFirst("gf") == ("abcdefghi", ""));
+
+  assertTrue("a/b/c/d".splitFirst("/") == ("a", "b/c/d"));
 }
 
 @test
@@ -282,9 +342,8 @@ fun testSubstringLarge(): void {
 @test
 fun testTrim(): void {
   assertEqual("".trim(), "");
-  assertEqual("a".trim(), "a");
+  assertEqual("a".trimRight(), "a");
   assertEqual("  a  ".trim(), "a");
-
   // All the special characters
   assertEqual("\u0020".trim(), "");
   assertEqual("\u00A0".trim(), "");
@@ -423,4 +482,75 @@ fun testToFromUtf8(): void {
     .map(UInt8::truncate);
   assertEqual(phrase.utf8().collect(Array), phraseBytes);
   assertEqual(String::fromUtf8(phraseBytes), phrase);
+}
+
+@test
+fun testIterSearch(): void {
+  expectFind = (str, pat, exp) -> {
+    i = str.getIter();
+    assertTrue(i.search(pat));
+    assertEqual(String::fromChars(i.collect(Array)), exp);
+  };
+
+  expectNotFind = (str, pat) -> {
+    i = str.getIter();
+    assertFalse(i.search(pat));
+    assertEqual(String::fromChars(i.collect(Array)), "");
+  };
+
+  expectFind("abcde", "a", "abcde");
+  expectFind("abcde", "b", "bcde");
+  expectFind("abcde", "c", "cde");
+  expectFind("abcde", "d", "de");
+  expectFind("abcde", "e", "e");
+  expectNotFind("abcde", "f");
+  expectFind("abcdeabcde", "c", "cdeabcde");
+
+  expectFind("abcde", "ab", "abcde");
+
+  expectFind("abcde", "bc", "bcde");
+  expectNotFind("abcde", "ef");
+  expectFind("abcdeabcde", "bc", "bcdeabcde");
+
+  expectNotFind("abcde", "abcdef");
+}
+
+@test
+fun testIterRSearch(): void {
+  expectFind = (str, pat, exp) -> {
+    i = str.getEndIter();
+    assertTrue(i.rsearch(pat));
+    assertEqual(String::fromChars(i.collect(Array)), exp);
+  };
+
+  expectNotFind = (str, pat) -> {
+    i = str.getEndIter();
+    assertFalse(i.rsearch(pat));
+    assertEqual(String::fromChars(i.collect(Array)), str);
+  };
+
+  expectFind("abcde", "a", "abcde");
+  expectFind("abcde", "b", "bcde");
+  expectFind("abcde", "c", "cde");
+  expectFind("abcde", "d", "de");
+  expectFind("abcde", "e", "e");
+  expectNotFind("abcde", "f");
+
+  expectFind("abcdeabcde", "c", "cde");
+
+  expectFind("abcde", "ab", "abcde");
+  expectFind("abcde", "bc", "bcde");
+  expectNotFind("abcde", "ef");
+  expectFind("abcdeabcde", "bc", "bcde");
+
+  expectNotFind("abcde", "abcdef");
+}
+
+@test
+fun testTakeUntil(): void {
+  x = "abcde";
+  assertEqual(
+    x.getIter().forward(1).takeUntil(x.getEndIter().rewind(1)),
+    "bcd",
+  );
 }

--- a/tests/src/runtime/prelude/stdlib/TextRangeTest.sk
+++ b/tests/src/runtime/prelude/stdlib/TextRangeTest.sk
@@ -1,0 +1,47 @@
+@test
+fun testContentFromLines(): void {
+  text = Vector[
+    "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse",
+    "imperdiet diam id velit interdum, ac ultrices metus fermentum.",
+    "Suspendisse vehicula vestibulum ipsum eget tempus. Pellentesque sagittis",
+    "nisl vitae nunc blandit, auctor accumsan nibh porta. Vivamus ipsum",
+    "risus, viverra ut pellentesque vitae, accumsan quis mauris. Duis felis",
+    "tortor interdum at quam eget, auctor suscipit turpis. Duis imperdiet",
+    "tincidunt iaculis. Vestibulum id neque nunc. Aliquam vel facilisis orci,",
+    "lacinia sollicitudin purus. Sed sed sem lacus. Morbi magna ligula,",
+  ];
+
+  assertEqual(
+    TextRange.contentFromLines(
+      TextRange{
+        start => Position::create(1, 20),
+        end => Position::create(3, 20),
+      },
+      text,
+    ),
+    "lit interdum, ac ultrices metus fermentum.\nSuspendisse vehicula " +
+      "vestibulum ipsum eget tempus. Pellentesque sagittis\nnisl vitae nunc " +
+      "blan",
+  );
+
+  assertEqual(
+    TextRange.contentFromLines(
+      TextRange{
+        start => Position::create(0, 5),
+        end => Position::create(0, 30),
+      },
+      text,
+    ),
+    " ipsum dolor sit amet, co",
+  );
+
+  assertThrows(() -> {
+    TextRange.contentFromLines(
+      TextRange{
+        start => Position::create(7, 5),
+        end => Position::create(8, 30),
+      },
+      text,
+    )
+  });
+}


### PR DESCRIPTION
Lots of code was abusing String::get() (and String::unsafe_get()) ending up in O(n^2) behavior.  Removed String::get() and modified the String API to work better with StringIterator.

