### PR TITLE
Fix missing dependency

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -3,6 +3,7 @@
     "start": "docusaurus-start --port 8082"
   },
   "dependencies": {
+    "convert-source-map": "^1.6.0",
     "docusaurus": "^1.0.13",
     "express-http-proxy": "^1.0.6"
   }


### PR DESCRIPTION
```
> gifsicle@3.0.4 postinstall /mnt/c/Users/rini/Downloads/website/website/node_modules/gifsicle
> node lib/install.js

module.js:550
    throw err;
    ^

Error: Cannot find module 'convert-source-map'
    at Function.Module._resolveFilename (module.js:548:15)
    at Function.Module._load (module.js:475:25)
    at Module.require (module.js:597:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (/mnt/c/Users/rini/Downloads/website/website/node_modules/gulp-sourcemaps/index.js:6:15)
    at Module._compile (module.js:653:30)
    at Object.Module._extensions..js (module.js:664:10)
    at Module.load (module.js:566:32)
    at tryModuleLoad (module.js:506:12)
    at Function.Module._load (module.js:498:3)
npm WARN website No repository field.
npm WARN website No license field.
```