### PR TITLE
Ubuntu distribution scripts.

### DIFF
--- a/build-static-binaries.sh
+++ b/build-static-binaries.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+###############################################################################
+# This scripts builds a static version of skip_server and skip_printer.
+# Static in the sense that the resulting binaries will not attempt to load
+# any dynamic library (cf -static option of clang).
+#
+# The only reason to build those binaries is that they will be much easier
+# to distribute. When you link with a dynamic library, you need the same
+# library to be available on the system that will run the binary.
+#
+# That can be difficult to get right, especially when you have quite a few
+# of them.
+###############################################################################
+
+buildStatic() {
+
+    echo "Building: /tmp/$1.ll"
+    rm -Rf "/tmp/$1.ll"
+
+    cat ./build/src/runtime/native/lib/preamble.ll > "/tmp/$1.ll"
+    ./build/lkg/bin/skip_to_llvm --export-function-as main=skip_main "$2" >> "/tmp/$1.ll"
+
+    if [ -f "/tmp/$1.ll" ]; then
+	echo "Written: /tmp/$1.ll"
+    else
+	exit 2
+    fi
+
+    echo "Building: /tmp/$1.o"
+    rm -Rf "/tmp/$1.o"
+
+    clang++ -c -O3 "/tmp/$1.ll" -o "/tmp/$1_full.o"
+    strip --strip-symbol=exit "/tmp/$1_full.o" -o "/tmp/$1.o"
+
+    if [ -f "/tmp/$1.o" ]; then
+	echo "Written: /tmp/$1.o"
+    else
+	exit 2
+    fi
+
+    echo "Building: ./build/bin/static_skip_server"
+    rm -rf "./build/bin/$1"
+
+    clang++ -static -s -o "build/bin/$1" -g ./build/src/runtime/native/CMakeFiles/skip_runtime.src.dir/src/String.cpp.o "/tmp/$1.o" ./build/src/runtime/native/CMakeFiles/sk_standalone.src.dir/src/sk_standalone.cpp.o -L./build/third-party/install/lib/ -L/usr/lib/x86_64-linux-gnu ./build/src/runtime/native/libskip_runtime.a -fPIC -DPIC -Wl,-rpath,/usr/lib/x86_64-linux-gnu -lboost_thread -lboost_context -lboost_atomic -lrt -Wl,--gc-sections -DUSE_JEMALLOC -msse4.2 -std=c++14 -O3 -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fdata-sections -ffunction-sections -DFOLLY_HAVE_MALLOC_H -lfolly -lglog -lgflags -ldouble-conversion -licuuc -licui18n -licuio -licutu -licudata -ljemalloc_pic -lpcre -lboost_system -lboost_filesystem -lboost_chrono -lboost_date_time -levent -ldl -lpthread -lunwind -static -lboost_context
+
+    if [ -f "./build/bin/$1" ]; then
+	echo "Written: $PWD/build/bin/$1"
+    fi
+}
+
+if ! [ -f build/bin/skip_server ]; then
+    2>&1 echo "Could not find ./build/bin/skip_server"
+    2>&1 echo "1- This script only works when run from the root skip dir"
+    2>&1 echo "2- skip_server must be built, $ cd build && ninja skip_server"
+    exit 2
+fi
+
+if ! [ -f build/bin/skip_printer ]; then
+    2>&1 echo "Could not find ./build/bin/skip_printer"
+    2>&1 echo "1- This script only works when run from the root skip dir"
+    2>&1 echo "2- skip_printer must be built, $ cd build && ninja skip_printer"
+    exit 2
+fi
+
+buildStatic static_skip_server src/server
+buildStatic static_skip_printer src/tools:skip_printer

--- a/prepare-release.sh
+++ b/prepare-release.sh
@@ -26,13 +26,18 @@ mkdir "$installDir/lib"
 cp "$pathToSkip/sktools/install.sh" "$installDir/install.sh"
 cp "$pathToSkip/sktools/INSTALL.md" "$installDir/INSTALL.md"
 cp "$pathToSkip/sktools/sk" "$installDir/bin"
-if [ $distrib == Linux ]; then
-    strip --strip-unneeded "$pathToSkip/build/bin/skip_server" -o "$installDir/bin/skip_server"
-    strip --strip-unneeded "$pathToSkip/build/bin/skip_printer" -o "$installDir/bin/skip_printer"
-else
-    cp "$pathToSkip/build/bin/skip_server" "$installDir/bin/skip_server"
-    cp "$pathToSkip/build/bin/skip_printer" "$installDir/bin/skip_printer"
+
+if ! [ -f "$pathToSkip/build/bin/static_skip_server" ]; then
+    2>&1 echo "Missing static_skip_server. Did you run build-static-binaries.sh?"
 fi
+
+if ! [ -f "$pathToSkip/build/bin/static_skip_printer" ]; then
+    2>&1 echo "Missing static_skip_printer. Did you run build-static-binaries.sh?"
+fi
+
+# We want to build a version of the skip_server with everything linked statically
+cp "$pathToSkip/build/bin/static_skip_server" "$installDir/bin/skip_server"
+cp "$pathToSkip/build/bin/static_skip_printer" "$installDir/bin/skip_printer"
 
 cp -R src/runtime/prelude "$installDir/lib/prelude"
 
@@ -50,6 +55,21 @@ if [ $distrib == Linux ]; then
     cp "$pathToSkip/build/third-party/install/lib/libicutu.a" "$installDir/lib"
     cp "$pathToSkip/build/third-party/install/lib/libicudata.a" "$installDir/lib"
     cp "$pathToSkip/build/third-party/install/lib/libjemalloc_pic.a" "$installDir/lib"
+
+    linuxGnuLibDir="/usr/lib/x86_64-linux-gnu"
+
+    cp "$linuxGnuLibDir/libglog.a" "$installDir/lib"
+    cp "$linuxGnuLibDir/libgflags.a" "$installDir/lib"
+    cp "$linuxGnuLibDir/libpcre.a" "$installDir/lib"
+    cp "$linuxGnuLibDir/libboost_thread.a" "$installDir/lib"
+    cp "$linuxGnuLibDir/libboost_system.a" "$installDir/lib"
+    cp "$linuxGnuLibDir/libboost_context.a" "$installDir/lib"
+    cp "$linuxGnuLibDir/libboost_filesystem.a" "$installDir/lib"
+    cp "$linuxGnuLibDir/libboost_chrono.a" "$installDir/lib"
+    cp "$linuxGnuLibDir/libboost_date_time.a" "$installDir/lib"
+    cp "$linuxGnuLibDir/libboost_atomic.a" "$installDir/lib"
+    cp "$linuxGnuLibDir/libevent.a" "$installDir/lib"
 fi
 
 cp "$pathToSkip/sktools/sk" "$installDir/bin/sk"
+cp -R "$pathToSkip/ide" "$installDir/ide"

--- a/sktools/sk
+++ b/sktools/sk
@@ -113,6 +113,12 @@ if [ $command == "stop" ]; then
 fi
 
 start() {
+    skip_server_pid=`ps xa | grep skip_server | grep "$root" | awk '{ print $1 }'`
+    if [ "$skip_server_pid" ]; then
+        >&2 echo "Another server is already running"
+        exit 2
+    fi
+
     fifo_command="$skdir/fifo_command"
     fifo_response="$skdir/fifo_response"
 
@@ -279,7 +285,6 @@ if [ $command == "build" ]; then
     fi
 
     "$clangpp" -O3 -g -c "$skdir/preamble_and_out.ll" -o "$skdir/preamble_and_out.o"
-
     if [ "$system" == "Linux" ]; then
 
       # Linking it all together
@@ -287,10 +292,7 @@ if [ $command == "build" ]; then
              "$skdir/preamble_and_out.o" "$standalone" \
 	     -L"$thirdPartyLibDir/" \
 	     "$skipRuntimeLib" \
-	     -fPIC -DPIC -Wl,-rpath,"$linuxGnuLibDir" \
-	     -lboost_thread \
-	     -lboost_context \
-	     -lboost_atomic \
+	     -fPIC -DPIC \
 	     -lrt \
 	     -Wl,--gc-sections \
 	     -DUSE_JEMALLOC -msse4.2 -std=c++14 \
@@ -300,9 +302,13 @@ if [ $command == "build" ]; then
 	     -licuuc -licui18n -licuio -licutu -licudata -ljemalloc_pic \
 	     -lpcre -lboost_system \
 	     -lboost_filesystem -lboost_chrono -lboost_date_time \
-	     -levent -ldl \
+	     -levent \
 	     -lpthread \
 	     -lunwind \
+	     -lboost_thread \
+	     -lboost_context \
+	     -lboost_atomic \
+	     -ldl \
 	     $ccopts
     else
 	if [ "$system" == "Darwin" ]; then

--- a/src/native/specialize.sk
+++ b/src/native/specialize.sk
@@ -368,7 +368,7 @@ mutable class Specializer{
 
   hhvmTypeTable: HhvmTypeTable = HhvmTypeTable.empty(),
 
-  // Updated as we go to point to something related to what we are specializing.
+  // Updated OBas we go to point to something related to what we are specializing.
   mutable pos: Pos,
 } extends ClassLookupEnv {
   static fun make(


### PR DESCRIPTION
Adding everything necessary for a binary ubuntu distribution. I made sure
that everything was working on a fresh 18.04 install with only clang-6.0 installed.

What was necessary:
- Compile skip_server and skip_printer statically (to avoid dependencies)
- Added the libraries that we need into the skip distribution
