### PR TITLE
Fix CI: Reinstall broken nodejs on OSX container.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -310,6 +310,7 @@ jobs:
             for item in ninja cmake dwarfutils libelf boost libevent gflags glog jemalloc node autoconf automake pkg-config libtool; do
             brew info "${item}" | grep -q 'Not installed' && brew install "${item}"
             done
+            brew reinstall node
       - run:
           name: configure
           working_directory: ~/skip/build


### PR DESCRIPTION
Before this PR, the build on OSX fails with:
```
-- Found node: /usr/local/bin/node
dyld: Library not loaded: /usr/local/opt/icu4c/lib/libicui18n.61.dylib
  Referenced from: /usr/local/bin/node
  Reason: image not found
```