### PR TITLE
Fix frozen lambda captures untracked

### DIFF
--- a/src/frontend/skipTypes.sk
+++ b/src/frontend/skipTypes.sk
@@ -2956,9 +2956,10 @@ private fun is_frozen_map(
 }
 
 fun is_frozen_tfun_modifiers(mods: N.Tfun_modifiers): Bool {
-  (purity, _) = mods;
-  invariant(!purity.isEmpty(), "impposible tfun");
-  purity[0] is N.Fpure()
+  (purity, tracking) = mods;
+  invariant(!purity.isEmpty(), "imposible tfun");
+  invariant(!tracking.isEmpty(), "imposible tfun");
+  purity[0] is N.Fpure() && tracking[0] is N.Ftracked()
 }
 
 private fun is_frozen_map_tparam(

--- a/src/frontend/skipTyping.sk
+++ b/src/frontend/skipTyping.sk
@@ -2392,7 +2392,7 @@ fun expr_(
       (acc, (vty_fixed, (pos1, TAst.Local(n))))
     | None() if (SkipNaming.maybeGetFun(n.i1).isSome()) ->
       fd = SkipNaming.getFun(n);
-      (acc1, subst, targs) = TUtils.mk_tparams(next_id, pos1, acc, fd.tparams);
+      (!acc, subst, targs) = TUtils.mk_tparams(next_id, pos1, acc, fd.tparams);
       tracking = SkipNaming.make_tfun_tracking(fd.untracked_);
       params_ty = TUtils.make_params_type(
         subst,
@@ -2400,7 +2400,7 @@ fun expr_(
         fd.params,
       );
       rty = TUtils.type_subst(subst, acc, fd.return_);
-      ty = (
+      origTy = (
         pos1,
         N.Tfun(
           Ast.Vnone(),
@@ -2410,8 +2410,10 @@ fun expr_(
           rty,
         ),
       );
+      level = -1;
+      (!acc, ty) = check_local_mutable(env, acc, pos1, level, origTy);
       e1 = (pos1, TAst.Fun(n, targs));
-      (acc1, (ty, e1))
+      (acc, (ty, e1))
     | None() if (SkipNaming.maybeGetConst(n.i1).isSome()) ->
       ty = SkipNaming.getConst(n).type;
       (acc, (ty, (pos1, TAst.Const(n))))

--- a/src/frontend/skipTypingUtils.sk
+++ b/src/frontend/skipTypingUtils.sk
@@ -700,7 +700,7 @@ class MutPreservationConstraint(
 }
 
 // Constraint for checking that checking mutable locals weren't captured
-class LocalMutableCosntraint(
+class LocalMutableConstraint(
   level: NoMutableFrozenLevel,
   fr: FileRange,
   ty: N.Type_,
@@ -763,7 +763,7 @@ fun check_mutable_error_msg(mutability: N.EffectiveNotFrozen): String {
 
 value class Constraints(
   private typing: List<TypingConstraint>,
-  private locals: List<LocalMutableCosntraint>,
+  private locals: List<LocalMutableConstraint>,
 ) {
   fun add(fr: FileRange, lty: N.Type_, rtys: Array<N.Type_>): this {
     !this.typing = List.Cons(RelationalConstraint(fr, lty, rtys), this.typing);
@@ -776,7 +776,7 @@ value class Constraints(
     ty: N.Type_,
   ): this {
     !this.locals = List.Cons(
-      LocalMutableCosntraint(level, fr, ty),
+      LocalMutableConstraint(level, fr, ty),
       this.locals,
     );
     this
@@ -801,7 +801,7 @@ value class Constraints(
     | t @ TypingConstraint _ ->
       !this.typing = List.Cons(t, this.typing);
       this
-    | l @ LocalMutableCosntraint _ ->
+    | l @ LocalMutableConstraint _ ->
       !this.locals = List.Cons(l, this.locals);
       this
     }

--- a/test.sh
+++ b/test.sh
@@ -8,7 +8,7 @@
 dir=$(dirname "$0")
 
 if [[ $BACKEND == "" ]]; then
-  BACKEND="js"
+  BACKEND="native"
 fi
 FILES=$(cd $dir; find . \! \( \( -path ./build -o -path ./native -o -path ./.git \) -prune \)  -not -name .#\* -name '*.sk')
 TARGETS=$(cd $dir/build; ninja -t targets | sed -e 's/:.*//')

--- a/tests/src/frontend/typechecking/invalid/frozen_lambda_captures_untracked.exp_err
+++ b/tests/src/frontend/typechecking/invalid/frozen_lambda_captures_untracked.exp_err
@@ -1,0 +1,24 @@
+File "./typechecking/invalid/frozen_lambda_captures_untracked.sk", line 6, characters 13-15:
+You cannot capture this variable
+4 |
+5 | untracked fun main(): void {
+6 |   _ = () ~> foo();
+  |             ^^^
+7 | }
+
+File "./typechecking/invalid/frozen_lambda_captures_untracked.sk", line 6, characters 13-15:
+Mutable because of this position
+4 |
+5 | untracked fun main(): void {
+6 |   _ = () ~> foo();
+  |             ^^^
+7 | }
+
+File "./typechecking/invalid/frozen_lambda_captures_untracked.sk", line 6, characters 7-17:
+Because this closure was declared as pure (~>)
+Try '->' instead
+4 |
+5 | untracked fun main(): void {
+6 |   _ = () ~> foo();
+  |       ^^^^^^^^^^^
+7 | }

--- a/tests/src/frontend/typechecking/invalid/frozen_lambda_captures_untracked.sk
+++ b/tests/src/frontend/typechecking/invalid/frozen_lambda_captures_untracked.sk
@@ -1,0 +1,7 @@
+untracked fun foo(): Int {
+  0
+}
+
+untracked fun main(): void {
+  _ = () ~> foo();
+}


### PR DESCRIPTION
Untracked functions should be treated as mutable. They should not be able to escape inside async or pure lambdas. Fixes #74