### PR TITLE
Making the keys and the source of a reactive table generic.

### DIFF
--- a/src/frontend/skipExpand.sk
+++ b/src/frontend/skipExpand.sk
@@ -63,7 +63,11 @@ module alias A = SkipAst;
 /*****************************************************************************/
 module ChildMap;
 
-const childCache: Reactive.Table<String> = Reactive.Table::create();
+const childCache: Reactive.Table<
+  String,
+  String,
+  String,
+> = Reactive.Table::create();
 
 memoized fun getChildren(className: String): SSet {
   childCache[className].foldl(
@@ -179,7 +183,11 @@ module end;
 
 module ModuleMap;
 
-const moduleCache: Reactive.Table<String> = Reactive.Table::create();
+const moduleCache: Reactive.Table<
+  String,
+  String,
+  String,
+> = Reactive.Table::create();
 
 fun containsKey(key: String): Bool {
   moduleCache.get(key).size() > 0
@@ -755,7 +763,11 @@ fun malias_type_def_<Ta>(
  * file).
  */
 /*****************************************************************************/
-const fileCache: Reactive.Table<String> = Reactive.Table::create();
+const fileCache: Reactive.Table<
+  String,
+  String,
+  String,
+> = Reactive.Table::create();
 
 mutable private class FileMapBuilder{private mutable currentModule: Module_} {
   static fun create(): mutable this {

--- a/src/runtime/prelude/native/Reactive.sk
+++ b/src/runtime/prelude/native/Reactive.sk
@@ -83,11 +83,6 @@ class Box<T: frozen> private (
     unsafe(this).compare(unsafe(value2))
   }
 }
-class Box2<T>(T, T) extends Boxed<T>
-
-native base class Pointer {
-  fun compare(): void;
-}
 
 private class RefCountedTable<T: frozen>(
   cache: Reactive.GlobalCache<Map<Box<T>, Int>>,
@@ -212,9 +207,9 @@ private fun diffArrays<T: frozen>(
   (toAdd.toArray(), toRemove.toArray())
 }
 
-class Table<T: frozen> private {
-  refCountedTable: RefCountedTable<T>,
-  sourceTable: Reactive.GlobalCache<Array<Box<T>>>,
+class Table<Source: frozen, Key: frozen, Value: frozen> private {
+  refCountedTable: RefCountedTable<Value>,
+  sourceTable: Reactive.GlobalCache<Array<Box<Value>>>,
 } {
   static fun create(): this {
     static{
@@ -223,7 +218,17 @@ class Table<T: frozen> private {
     }
   }
 
-  untracked fun set(source: String, key: String, origValues: Array<T>): void {
+  private static fun frozenToString<T: frozen>(x: T): String {
+    unsafe(intern(x)).toString()
+  }
+
+  untracked fun set(
+    origSource: Source,
+    origKey: Key,
+    origValues: Array<Value>,
+  ): void {
+    source = static::frozenToString(origSource);
+    key = static::frozenToString(origKey);
     values = origValues.map(x -> Box::create(x));
     sourceKey = source + ":" + key;
     newValues = {
@@ -243,7 +248,8 @@ class Table<T: frozen> private {
     }
   }
 
-  fun get(key: String): Array<T> {
+  fun get(origKey: Key): Array<Value> {
+    key = static::frozenToString(origKey);
     this.refCountedTable.get(key).map(x -> x.value)
   }
 }
@@ -255,7 +261,7 @@ module TestReactive;
 class TestFailure() extends Exception
 
 fun testTable(
-  rtable: Reactive.Table<String>,
+  rtable: Reactive.Table<String, String, String>,
   map: readonly Map<(String, String), Array<String>>,
   keyRange: Int,
 ): void {

--- a/tests/runtime/prelude/native/Reactive.sk
+++ b/tests/runtime/prelude/native/Reactive.sk
@@ -83,11 +83,6 @@ class Box<T: frozen> private (
     unsafe(this).compare(unsafe(value2))
   }
 }
-class Box2<T>(T, T) extends Boxed<T>
-
-native base class Pointer {
-  fun compare(): void;
-}
 
 private class RefCountedTable<T: frozen>(
   cache: Reactive.GlobalCache<Map<Box<T>, Int>>,
@@ -212,9 +207,9 @@ private fun diffArrays<T: frozen>(
   (toAdd.toArray(), toRemove.toArray())
 }
 
-class Table<T: frozen> private {
-  refCountedTable: RefCountedTable<T>,
-  sourceTable: Reactive.GlobalCache<Array<Box<T>>>,
+class Table<Source: frozen, Key: frozen, Value: frozen> private {
+  refCountedTable: RefCountedTable<Value>,
+  sourceTable: Reactive.GlobalCache<Array<Box<Value>>>,
 } {
   static fun create(): this {
     static{
@@ -223,7 +218,17 @@ class Table<T: frozen> private {
     }
   }
 
-  untracked fun set(source: String, key: String, origValues: Array<T>): void {
+  private static fun frozenToString<T: frozen>(x: T): String {
+    unsafe(intern(x)).toString()
+  }
+
+  untracked fun set(
+    origSource: Source,
+    origKey: Key,
+    origValues: Array<Value>,
+  ): void {
+    source = static::frozenToString(origSource);
+    key = static::frozenToString(origKey);
     values = origValues.map(x -> Box::create(x));
     sourceKey = source + ":" + key;
     newValues = {
@@ -243,7 +248,8 @@ class Table<T: frozen> private {
     }
   }
 
-  fun get(key: String): Array<T> {
+  fun get(origKey: Key): Array<Value> {
+    key = static::frozenToString(origKey);
     this.refCountedTable.get(key).map(x -> x.value)
   }
 }
@@ -255,7 +261,7 @@ module TestReactive;
 class TestFailure() extends Exception
 
 fun testTable(
-  rtable: Reactive.Table<String>,
+  rtable: Reactive.Table<String, String, String>,
   map: readonly Map<(String, String), Array<String>>,
   keyRange: Int,
 ): void {


### PR DESCRIPTION
Right now, the keys used by global tables are generic.
Reminder: reactive tables are tables where the keys are tracked by
the runtime the same way it would track and external dependency.

So the problem is that sometimes we will want to track keys that
are not strings. This diffs allows us to do that. What we do instead
of using a string is that we first intern it (to create a unique pointer
associated with the object), then take the interned pointer, turn it into
an int, and then turn that into a string.

Sure, we could probably have used the Int directly ... But this will
do, at least for now.
