### PR TITLE
Make io untracked

### DIFF
--- a/src/native/AsmOutput.sk
+++ b/src/native/AsmOutput.sk
@@ -1108,7 +1108,7 @@ private fun partitionOutputFiles(
   files.zip(isInternal)
 }
 
-fun writeOutputFiles(
+untracked fun writeOutputFiles(
   defs: readonly AsmOutput.AsmDefIDToAsmDef,
   inputFiles: Array<String>,
 ): void {

--- a/src/nuclide/LspServer.sk
+++ b/src/nuclide/LspServer.sk
@@ -278,8 +278,11 @@ mutable class LspServer{
         this.consoleLog(`Type checking: ${filename}`);
 
         errors = SkipAnalyze.analyzeFile(filename);
+        errorsStr = SkipError.errorsToString(errors);
 
-        this.consoleLog(`Done type checking: ${filename}. ${errors} errors.`);
+        this.consoleLog(
+          `Done type checking: ${filename}. ${errorsStr} errors.`,
+        );
         this.logLeakCounters(Array["Invocation", "Revision"]);
 
         this.setTypeErrors(errorsToDiagnostics(errors));

--- a/src/nuclide/outline.sk
+++ b/src/nuclide/outline.sk
@@ -273,7 +273,7 @@ fun treeToJson(tree: ParseTree): JSON.Value {
   treeToOptionJson(tree).fromSome()
 }
 
-fun processFile(fileName: String): void {
+untracked fun processFile(fileName: String): void {
   outline(FileSystem.readTextFile(fileName))
 }
 

--- a/src/nuclide/outline.sk
+++ b/src/nuclide/outline.sk
@@ -282,7 +282,9 @@ untracked fun main(): void {
   if (args.isEmpty()) {
     outline(read_stdin());
   } else {
-    args.each(processFile);
+    for (arg in args) {
+      processFile(arg);
+    }
   };
   void
 }

--- a/src/nuclide/skipCheck.sk
+++ b/src/nuclide/skipCheck.sk
@@ -16,5 +16,9 @@
 /*****************************************************************************/
 
 untracked fun main(): void {
-  print_raw(SkipAnalyze.analyzeFile(SkipAnalyze.pathOfArguments()).join("\n"))
+  print_raw(
+    SkipError.errorsToString(
+      SkipAnalyze.analyzeFile(SkipAnalyze.pathOfArguments()),
+    ),
+  )
 }

--- a/src/project/SkipDepends.sk
+++ b/src/project/SkipDepends.sk
@@ -82,7 +82,7 @@ fun parseArguments(): Arguments {
   args
 }
 
-fun processTarget(
+untracked fun processTarget(
   bindings: Map<String, String>,
   target: String,
   sourceOnly: Bool,
@@ -110,7 +110,7 @@ fun processTarget(
 
 module end;
 
-fun main(): void {
+untracked fun main(): void {
   args = SkipProject.parseArguments();
   for (target in args.targets) {
     SkipProject.processTarget(args.bindings, target, args.sourceOnly)

--- a/src/project/SkipDepends.sk
+++ b/src/project/SkipDepends.sk
@@ -92,7 +92,7 @@ untracked fun processTarget(
   | Some(SourceFileArgument{filename}) -> print_string(filename)
   | Some(ProgramUnitArgument{projectPath, programUnit}) ->
     print_string(
-      SkipError.doAndReportErrors(() ~>
+      SkipError.doAndReportErrors(() ->
         loadProjectProgramUnit(projectPath, programUnit).flatMap(solutionKey ~> {
           (solution, key) = solutionKey;
           solution.getAllSourceFilesFor(key, bindings).map(sourceFiles ~> {

--- a/src/project/SkipProject.sk
+++ b/src/project/SkipProject.sk
@@ -410,7 +410,7 @@ class ProgramUnitArgument{
 
 // projectPath of "" uses the current directory.
 // programUnitName of "" means the default program unit in the project.
-fun loadProjectProgramUnit(
+untracked fun loadProjectProgramUnit(
   projectPath: String,
   programUnitName: String,
 ): Result<(Solution, ProgramUnitKey), Vector<SkipError.Error>> {
@@ -421,7 +421,7 @@ fun loadProjectProgramUnit(
   );
 }
 
-fun filesOfProjectProgramUnit(
+untracked fun filesOfProjectProgramUnit(
   bindings: Map<String, String>,
   projectPath: String,
   programUnitName: String,
@@ -432,7 +432,7 @@ fun filesOfProjectProgramUnit(
 }
 
 // Gets the set of files for a compilation target.
-fun getFilesForTarget(
+untracked fun getFilesForTarget(
   bindings: Map<String, String>,
   target: String,
 ): Result<Set<String>, Vector<SkipError.Error>> {
@@ -456,7 +456,7 @@ fun getFilesForTarget(
   };
 }
 
-fun getFilesForTargets(
+untracked fun getFilesForTargets(
   bindings: Map<String, String>,
   targets: Vector<String>,
 ): Set<String> {

--- a/src/project/SkipProject.sk
+++ b/src/project/SkipProject.sk
@@ -464,8 +464,8 @@ untracked fun getFilesForTargets(
   // Shouldn't be a significant issue in practice, as most of the time there
   // will be exactly one target.
   targets
-    .map(target ~>
-      SkipError.doAndReportErrors(() ~> getFilesForTarget(bindings, target))
+    .map(target ->
+      SkipError.doAndReportErrors(() -> getFilesForTarget(bindings, target))
     )
     .reduce((t1, t2) ~> t1.union(t2), Set[]);
 }

--- a/src/project/SolutionLoader.sk
+++ b/src/project/SolutionLoader.sk
@@ -123,7 +123,7 @@ mutable class SolutionLoader{
   fileToInfo: mutable Map<String, FileInfo> = mutable Map[],
   programUnits: mutable Map<ProgramUnitKey, ProgramUnit> = mutable Map[],
 } {
-  static fun load(
+  static untracked fun load(
     rootProjectPath: String,
   ): Result<Solution, Vector<SkipError.Error>> {
     invariant(
@@ -151,7 +151,7 @@ mutable class SolutionLoader{
     };
   }
 
-  mutable fun loadProjects(): void {
+  mutable untracked fun loadProjects(): void {
     log("loading projects");
     this.loadProject(this.rootProjectPath);
     if (this.hadErrors()) return void;
@@ -197,7 +197,7 @@ mutable class SolutionLoader{
     this.errors.push(createError(projectDir, message, relatedProjects));
   }
 
-  mutable fun loadProject(dirname: String): void {
+  mutable untracked fun loadProject(dirname: String): void {
     invariant(Path.isNormalized(dirname));
     if (this.projects.containsKey(dirname)) {
       return void;
@@ -287,10 +287,11 @@ mutable class SolutionLoader{
     };
   }
 
-  mutable fun loadReferencedProjects(project: Project): void {
+  mutable untracked fun loadReferencedProjects(project: Project): void {
     this.loadingPath.push(project);
-
-    project.allReferencedProjects().each(this.loadProject);
+    for (referencedProject in project.allReferencedProjects()) {
+      this.loadProject(referencedProject);
+    };
 
     poppedProject = this.loadingPath.pop();
     invariant(project == poppedProject);

--- a/src/runtime/prelude/stdlib/filesystem/FileSystem.sk
+++ b/src/runtime/prelude/stdlib/filesystem/FileSystem.sk
@@ -16,7 +16,7 @@ module FileSystem;
 
 // This is really broken - you can't read a file into a String without an
 // encoding!
-fun readTextFile(filename: String): String {
+untracked fun readTextFile(filename: String): String {
   open_file(filename);
 }
 
@@ -92,7 +92,7 @@ fun readFilesRecursive(
 // TODO: Rename the C++ entrypoints and merge these into the
 // public API above.
 @cpp_runtime
-private native fun .open_file(String): String;
+untracked private native fun .open_file(String): String;
 
 @debug
 @cpp_runtime

--- a/src/runtime/tools/common.py
+++ b/src/runtime/tools/common.py
@@ -581,7 +581,7 @@ class RunCommand(object):
         if data:
             print('  %s%s:%s' % (RED, name, NORMAL))
             if limit:
-                lines = data.split('\n')
+                lines = data.decode().split('\n')
                 if len(lines) > limit[0]:
                     lines = ['<output truncated>'] + lines[-limit[0]:]
                 lines = map(lambda x: x if (len(x) < limit[1]) else (x[:limit[1] - 3] + '...'), lines)

--- a/src/runtime/tools/common.py
+++ b/src/runtime/tools/common.py
@@ -577,7 +577,7 @@ class RunCommand(object):
 
     def write_file(self, name, data, limit=None):
         assert not limit or (isinstance(limit, (tuple, list)) and len(limit) == 2)
-        data = data.encode('utf8').strip()
+        data = data.strip()
         if data:
             print('  %s%s:%s' % (RED, name, NORMAL))
             if limit:

--- a/src/runtime/tools/common.py
+++ b/src/runtime/tools/common.py
@@ -577,7 +577,7 @@ class RunCommand(object):
 
     def write_file(self, name, data, limit=None):
         assert not limit or (isinstance(limit, (tuple, list)) and len(limit) == 2)
-        data = data.strip()
+        data = data.encode('utf8').strip()
         if data:
             print('  %s%s:%s' % (RED, name, NORMAL))
             if limit:

--- a/src/server/skipServer.sk
+++ b/src/server/skipServer.sk
@@ -49,7 +49,7 @@ untracked fun compileLoop(target: String): void {
     errorStr = if (errors.isEmpty()) {
       "No errors!\n"
     } else {
-      errors.join("\n")
+      SkipError.errorsToString(errors)
     };
     writeFile(skdir + "/errors", errorStr);
     if (command == "build" && errors.isEmpty()) {

--- a/src/tools/CodeModMain.sk
+++ b/src/tools/CodeModMain.sk
@@ -52,12 +52,18 @@ fun transformSource(_source: String): String {
   invariant_violation("nothing to do")
 }
 
-fun transformFile(filename: String, transFn: String -> String): String {
+untracked fun transformFile(
+  filename: String,
+  transFn: String -> String,
+): String {
   source = FileSystem.readTextFile(filename);
   transFn(source);
 }
 
-fun transformFileInPlace(filename: String, transFn: String -> String): void {
+untracked fun transformFileInPlace(
+  filename: String,
+  transFn: String -> String,
+): void {
   try {
     result = transformFile(filename, transFn);
     FileSystem.writeTextFile(filename, result);
@@ -110,7 +116,7 @@ untracked fun main(): void {
 
   if (args.write) {
     // 0 or more files in place
-    _ = args.files.parallelMap(filename ~> {
+    _ = args.files.map(filename -> {
       print_string(filename);
       transformFileInPlace(filename, transFn);
     });

--- a/src/tools/SkipCollectAnnotations.sk
+++ b/src/tools/SkipCollectAnnotations.sk
@@ -140,7 +140,7 @@ untracked fun main(): void {
     args.bindings
   };
   sourceFiles = args.targets
-    .map(target ~> {
+    .map(target -> {
       SkipProject.TargetArgument::parse(target) match {
       | None() -> error(`Invalid target "${target}".\n`)
       | Some(targetArgument) ->
@@ -161,7 +161,7 @@ untracked fun getSourceFilesForTarget(
   target match {
   | SkipProject.SourceFileArgument{filename} -> Set[filename]
   | programUnit @ SkipProject.ProgramUnitArgument _ ->
-    SkipError.doAndReportErrors(() ~>
+    SkipError.doAndReportErrors(() ->
       SkipProject.loadProjectProgramUnit(
         programUnit.projectPath,
         programUnit.programUnit,
@@ -179,7 +179,7 @@ untracked fun collectionAnnotationTargets(
 ): Array<SkipAnnotations.FunctionAnnotation> {
   sourceFiles
     .collect(Array)
-    .parallelMap(sourceFile ~> {
+    .map(sourceFile -> {
       source = FileSystem.readTextFile(sourceFile);
       parseResults = SkipParser.parseSource(source, false);
       annotationTargets = mutable Vector[];

--- a/src/tools/SkipCollectAnnotations.sk
+++ b/src/tools/SkipCollectAnnotations.sk
@@ -132,7 +132,7 @@ fun parseArguments(): Arguments {
   args with {targets => rest.collect(Vector)}
 }
 
-fun main(): void {
+untracked fun main(): void {
   args = parseArguments();
   bindings = if (args.bindings.isEmpty()) {
     SkipProject.nativePreludeBindings
@@ -154,7 +154,7 @@ fun main(): void {
   printMainSource(annotationTargets, args.delegateFunction, print_raw);
 }
 
-fun getSourceFilesForTarget(
+untracked fun getSourceFilesForTarget(
   target: SkipProject.TargetArgument,
   bindings: Map<String, String>,
 ): Set<String> {
@@ -173,7 +173,7 @@ fun getSourceFilesForTarget(
   }
 }
 
-fun collectionAnnotationTargets(
+untracked fun collectionAnnotationTargets(
   sourceFiles: Sequence<String>,
   annotation: String,
 ): Array<SkipAnnotations.FunctionAnnotation> {

--- a/src/tools/SkipCollectAnnotations.sk
+++ b/src/tools/SkipCollectAnnotations.sk
@@ -239,6 +239,6 @@ fun printMainSource(
 
 module end;
 
-fun main(): void {
+untracked fun main(): void {
   SkipCollectAnnotations.main()
 }

--- a/src/tools/grammar.sk
+++ b/src/tools/grammar.sk
@@ -9,7 +9,7 @@
 
 type Comment = Token.Comment;
 
-fun main(): void {
+untracked fun main(): void {
   fileName: String = arguments()[0];
   contents = FileSystem.readTextFile(fileName);
   results = SkipParser.parseSource(contents, false);

--- a/src/tools/printerMain.sk
+++ b/src/tools/printerMain.sk
@@ -86,9 +86,13 @@ untracked fun main(): void {
     // Check if all the files passed are the same
     differents = files
       .collect(Vector)
-      .parallelMap(filename ~> {
+      .map(filename -> {
+        contents = FileSystem.readTextFile(filename);
+        (filename, contents)
+      })
+      .parallelMap(xy ~> {
+        (filename, contents) = xy;
         try {
-          contents = FileSystem.readTextFile(filename);
           prettyPrint(contents, filename).maybeSuccess().flatMap(formatted ~>
             if (formatted == contents) None() else Some(filename)
           )
@@ -108,7 +112,7 @@ untracked fun main(): void {
   } else if (args.write) {
     // 0 or more files in place
     // TODO: Should exit with an error code if unable to format all files?
-    _ = files.collect(Vector).parallelMap(filename ~> {
+    _ = files.collect(Vector).map(filename -> {
       print_raw(filename + "\n");
       try {
         contents = FileSystem.readTextFile(filename);

--- a/src/tools/printerMain.sk
+++ b/src/tools/printerMain.sk
@@ -43,10 +43,13 @@ fun prettyPrint(
   }
 }
 
-fun printToStdoutAndReportErrors(contents: String, filename: String): void {
+untracked fun printToStdoutAndReportErrors(
+  contents: String,
+  filename: String,
+): void {
   prettyPrint(contents, filename) match {
   | Failure(error) ->
-    print_error_ln(error.toString());
+    print_error_ln(SkipError.errorsToString(Vector[error]));
     exit(1)
   | Success(formattedContents) -> print_raw(formattedContents)
   }
@@ -110,7 +113,8 @@ untracked fun main(): void {
       try {
         contents = FileSystem.readTextFile(filename);
         prettyPrint(contents, filename) match {
-        | Failure(error) -> print_error_ln(error.toString())
+        | Failure(error) ->
+          print_error_ln(SkipError.errorsToString(Vector[error]))
         | Success(formattedContents) ->
           if (formattedContents != contents) {
             FileSystem.writeTextFile(filename, formattedContents)

--- a/src/tools/skipDocgen.sk
+++ b/src/tools/skipDocgen.sk
@@ -8,7 +8,7 @@
 // Unfortunately, comments are discarded in later passes of the compiler, so
 // we first extract comments via just the AST and put them in a map of the form
 //   "String.trim" -> "Some comment"
-fun extractComments(codeFiles: List<String>): Map<String, String> {
+untracked fun extractComments(codeFiles: List<String>): Map<String, String> {
   comments = mutable Map[];
   for (filename in codeFiles) {
     file_content = FileSystem.readTextFile(filename);

--- a/src/tools/skipSearch.sk
+++ b/src/tools/skipSearch.sk
@@ -43,7 +43,7 @@ mutable class SearchCodeMod{
   }
 }
 
-fun main(): void {
+untracked fun main(): void {
   args = arguments();
   if (args.size() < 2) {
     print_error_ln("Usage: skip_search pattern <list_of_sk_files>\n");
@@ -65,19 +65,22 @@ fun main(): void {
   };
   files = args.slice(1);
 
-  _ = files.collect(Vector).parallelMap(filename ~> {
-    source = FileSystem.readTextFile(filename);
-    results = SearchCodeMod::search(source, template);
-    if (results.size() > 0) {
-      lines = source.split("\n");
-      print_raw(
-        results
-          .map(x -> {
-            line = x.range.start.line();
-            filename + ":" + (line + 1) + " " + lines[line] + "\n"
-          })
-          .join(""),
-      )
-    }
-  })
+  _ = files
+    .collect(Vector)
+    .map(filename -> (filename, FileSystem.readTextFile(filename)))
+    .parallelMap(xy ~> {
+      (filename, source) = xy;
+      results = SearchCodeMod::search(source, template);
+      if (results.size() > 0) {
+        lines = source.split("\n");
+        print_raw(
+          results
+            .map(x -> {
+              line = x.range.start.line();
+              filename + ":" + (line + 1) + " " + lines[line] + "\n"
+            })
+            .join(""),
+        )
+      }
+    })
 }

--- a/src/tools/skipToAst.sk
+++ b/src/tools/skipToAst.sk
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-fun main(): void {
+untracked fun main(): void {
   filename = arguments()[0];
   contents = FileSystem.readTextFile(filename);
   try {

--- a/src/tools/skipToParseTree.sk
+++ b/src/tools/skipToParseTree.sk
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-fun main(): void {
+untracked fun main(): void {
   filename = arguments()[0];
   contents = FileSystem.readTextFile(filename);
 

--- a/src/utils/skipError.sk
+++ b/src/utils/skipError.sk
@@ -26,11 +26,7 @@ class Fix{
 class Error{
   traces: List<(FileRange, String)>,
   fix: ?Fix,
-} uses Show, Hashable, Equality {
-  fun toString(): String {
-    this.traces.map(traceToString).join("\n");
-  }
-
+} uses Hashable, Equality {
   fun filename(): String {
     this.traces.getHead().i0.filename;
   }
@@ -53,9 +49,25 @@ fun errorFromSyntaxError(error: SyntaxError, filename: String): Error {
   }
 }
 
+untracked fun errorsToString(errors: Vector<Error>): String {
+  strErrors = mutable Vector[];
+  for (error in errors) {
+    strTraces = mutable Vector[];
+    for (trace in error.traces) {
+      strTraces.push(traceToString(trace));
+    };
+    strErrors.push(strTraces.join("\n"));
+  };
+  strErrors.join("")
+}
+
+untracked fun printErrors(errors: Vector<Error>): void {
+  print_error(errorsToString(errors));
+}
+
 class SkipErrorException{errors: Vector<Error>} extends Exception {
   fun getMessage(): String {
-    this.errors.join("");
+    invariant_violation("Internal Error: should have used printErrors");
   }
 }
 
@@ -126,13 +138,13 @@ fun do4WithError<T1, T2, T3, T4>(
 }
 
 // Reports errors to stderr and exits if any errors are produced by operation.
-fun doAndReportErrors<T>(
+untracked fun doAndReportErrors<T>(
   operation: () -> Result<T, Vector<SkipError.Error>>,
 ): T {
   operation() match {
   | Success(result) -> result
   | Failure(errors) ->
-    print_error(errors.take(100).join("\n"));
+    printErrors(errors.take(100));
     exit(2)
   }
 }
@@ -158,11 +170,11 @@ private fun render_pos(pos: FileRange): String {
   file + position + "\n";
 }
 
-private fun traceToString(trace: Trace): String {
+private untracked fun traceToString(trace: Trace): String {
   render_pos(trace.i0) + trace.i1 + "\n" + get_context_of_pos(trace.i0);
 }
 
-private fun get_context_of_pos(
+private untracked fun get_context_of_pos(
   t: FileRange,
   fileContents: ?String = None(),
 ): String {

--- a/tests/runtime/prelude/stdlib/filesystem/FileSystem.sk
+++ b/tests/runtime/prelude/stdlib/filesystem/FileSystem.sk
@@ -16,7 +16,7 @@ module FileSystem;
 
 // This is really broken - you can't read a file into a String without an
 // encoding!
-fun readTextFile(filename: String): String {
+untracked fun readTextFile(filename: String): String {
   open_file(filename);
 }
 
@@ -92,7 +92,7 @@ fun readFilesRecursive(
 // TODO: Rename the C++ entrypoints and merge these into the
 // public API above.
 @cpp_runtime
-private native fun .open_file(String): String;
+untracked private native fun .open_file(String): String;
 
 @debug
 @cpp_runtime

--- a/tests/runtime/tools/common.py
+++ b/tests/runtime/tools/common.py
@@ -581,7 +581,7 @@ class RunCommand(object):
         if data:
             print('  %s%s:%s' % (RED, name, NORMAL))
             if limit:
-                lines = data.split('\n')
+                lines = data.decode().split('\n')
                 if len(lines) > limit[0]:
                     lines = ['<output truncated>'] + lines[-limit[0]:]
                 lines = map(lambda x: x if (len(x) < limit[1]) else (x[:limit[1] - 3] + '...'), lines)

--- a/tests/runtime/tools/common.py
+++ b/tests/runtime/tools/common.py
@@ -577,7 +577,7 @@ class RunCommand(object):
 
     def write_file(self, name, data, limit=None):
         assert not limit or (isinstance(limit, (tuple, list)) and len(limit) == 2)
-        data = data.encode('utf8').strip()
+        data = data.strip()
         if data:
             print('  %s%s:%s' % (RED, name, NORMAL))
             if limit:

--- a/tests/runtime/tools/common.py
+++ b/tests/runtime/tools/common.py
@@ -577,7 +577,7 @@ class RunCommand(object):
 
     def write_file(self, name, data, limit=None):
         assert not limit or (isinstance(limit, (tuple, list)) and len(limit) == 2)
-        data = data.strip()
+        data = data.encode('utf8').strip()
         if data:
             print('  %s%s:%s' % (RED, name, NORMAL))
             if limit:

--- a/tests/src/project/invalid/bad_parameter_value.exp_err
+++ b/tests/src/project/invalid/bad_parameter_value.exp_err
@@ -1,5 +1,4 @@
 File "invalid/bad_parameter_value/skip.project.json"
 Value 'missing' is not a valid value for variable 'v' in program unit 'lib'.
-
 File "invalid/bad_parameter_value/skip.project.json"
 Missing value 'val1' for variable 'v' in program unit 'lib'.

--- a/tests/src/runtime/prelude/SystemTest.sk
+++ b/tests/src/runtime/prelude/SystemTest.sk
@@ -13,7 +13,7 @@ untracked fun testNow(): void {
 }
 
 @test
-fun testOpenFile(): void {
+untracked fun testOpenFile(): void {
   x = FileSystem.readTextFile("tests/src/runtime/prelude/SystemTest.input");
   assertEqual(x, "This is a sample file.\n")
 }


### PR DESCRIPTION
A lot of operations on IO were not annotated as untracked. Which is wrong because they are have effects. This diff corrects that.