### PR TITLE
Make Skip use clang++-6.0 instead of just clang++

### DIFF
--- a/CMake/FindClang.cmake
+++ b/CMake/FindClang.cmake
@@ -11,9 +11,9 @@ endif()
 set(CLANG_FOUND FALSE CACHE BOOL "TRUE if CLANG was found")
 mark_as_advanced(CLANG_FOUND)
 
-find_program(CLANG_EXECUTABLE "clang++" HINTS ${HINT} /usr/lib/llvm-5.0/bin)
+find_program(CLANG_EXECUTABLE "clang++-6.0" HINTS ${HINT} /usr/lib/llvm-5.0/bin)
 if (NOT CLANG_EXECUTABLE)
-  message(FATAL_ERROR "clang++ is required")
+  message(FATAL_ERROR "clang++-6.0 is required")
 endif()
 
 execute_process(
@@ -25,8 +25,8 @@ string(REGEX REPLACE
   ".* version ([0-9]+\\.[0-9]+\\.[0-9]+)[ -].*"
   "\\1"
   CLANG_VERSION ${CLANG_VERSION})
-if(CLANG_VERSION VERSION_LESS "5.0.0")
-  message(FATAL_ERROR "clang version ${CLANG_VERSION} is incorrect. Need at least version 5.0.0. Please install a newer version.")
+if(CLANG_VERSION VERSION_LESS "6.0.0")
+  message(FATAL_ERROR "clang version ${CLANG_VERSION} is incorrect. Need version 6.0.0. Please install a newer version.")
 endif()
 
 set(CLANG_FOUND TRUE CACHE BOOL "TRUE if CLANG was found" FORCE)

--- a/CMake/FindClang.cmake
+++ b/CMake/FindClang.cmake
@@ -11,7 +11,7 @@ endif()
 set(CLANG_FOUND FALSE CACHE BOOL "TRUE if CLANG was found")
 mark_as_advanced(CLANG_FOUND)
 
-find_program(CLANG_EXECUTABLE "clang++-6.0" HINTS ${HINT} /usr/lib/llvm-5.0/bin)
+find_program(CLANG_EXECUTABLE "clang++-6.0" HINTS ${HINT} /usr/lib/llvm-6.0/bin)
 if (NOT CLANG_EXECUTABLE)
   message(FATAL_ERROR "clang++-6.0 is required")
 endif()

--- a/lkg/runtime/tools/skip_to_native
+++ b/lkg/runtime/tools/skip_to_native
@@ -263,7 +263,7 @@ def findProgram(args, name, env_var, cmake_var):
 
 
 def findClang(args):
-    return findProgram(args, 'clang++', 'CLANG', 'CLANG_EXECUTABLE')
+    return findProgram(args, 'clang++-6.0', 'CLANG', 'CLANG_EXECUTABLE')
 
 
 def main(stack):

--- a/src/runtime/tools/skip_to_native
+++ b/src/runtime/tools/skip_to_native
@@ -263,7 +263,7 @@ def findProgram(args, name, env_var, cmake_var):
 
 
 def findClang(args):
-    return findProgram(args, 'clang++', 'CLANG', 'CLANG_EXECUTABLE')
+    return findProgram(args, 'clang++-6.0', 'CLANG', 'CLANG_EXECUTABLE')
 
 
 def main(stack):

--- a/tests/runtime/tools/skip_to_native
+++ b/tests/runtime/tools/skip_to_native
@@ -263,7 +263,7 @@ def findProgram(args, name, env_var, cmake_var):
 
 
 def findClang(args):
-    return findProgram(args, 'clang++', 'CLANG', 'CLANG_EXECUTABLE')
+    return findProgram(args, 'clang++-6.0', 'CLANG', 'CLANG_EXECUTABLE')
 
 
 def main(stack):


### PR DESCRIPTION
The problem is that sometimes there will be multiple versions of
clang installed on the system. When that is the case, there is
a way to update the symbolic links cleanly by using update_alternatives.

The problem with that is that it forces the user to commit to a version
of clang on that system, or forces constant back end forth betweeen versions.

So we are just going to commit to one version of clang, for now 6,
something more recent when we are ready.
