### PR TITLE
Remove microlock

### DIFF
--- a/lkg/runtime/native/src/intern.cpp
+++ b/lkg/runtime/native/src/intern.cpp
@@ -1213,9 +1213,6 @@ void* rawShallowCloneObjectIntoIntern(
     size_t userByteSize,
     const RObj* userData,
     size_t numMetadataBytesToCopy) {
-  assert(
-      internedMetadataByteSize % sizeof(void*) == 0 &&
-      userByteSize % sizeof(void*) == 0);
 
   // We can't have a userByteSize of 0 - if we did then when we asked the memory
   // subsystem if the first non-metadata address is interned we'd actually be

--- a/src/runtime/native/include/skip/InternTable.h
+++ b/src/runtime/native/include/skip/InternTable.h
@@ -11,10 +11,11 @@
 
 #include "SmallTaggedPtr.h"
 
+#include <atomic>
+
 #include <boost/functional/hash.hpp>
 #include <boost/noncopyable.hpp>
 
-#include <folly/MicroLock.h>
 
 namespace skip {
 

--- a/src/runtime/native/include/skip/InternTable.h
+++ b/src/runtime/native/include/skip/InternTable.h
@@ -16,7 +16,6 @@
 #include <boost/functional/hash.hpp>
 #include <boost/noncopyable.hpp>
 
-
 namespace skip {
 
 /**

--- a/src/runtime/native/include/skip/util.h
+++ b/src/runtime/native/include/skip/util.h
@@ -9,6 +9,7 @@
 
 #include "fwd.h"
 
+#include <atomic>
 #include <cstdint>
 #include <type_traits>
 
@@ -186,4 +187,10 @@ void throwRuntimeErrorV(const char* msg, va_list ap)
 
 void throwRuntimeError(const char* msg, ...)
     __attribute__((__noreturn__, __format__(printf, 1, 2)));
+
+struct SpinLock {
+  std::atomic<uintptr_t> m_bits;
+  void lock();
+  void unlock();
+};
 } // namespace skip

--- a/src/runtime/native/include/skip/util.h
+++ b/src/runtime/native/include/skip/util.h
@@ -18,6 +18,8 @@
 #include <folly/lang/Bits.h>
 #include <folly/Memory.h>
 
+#include <folly/MicroLock.h>
+
 // #define ENABLE_DEBUG_TRACE 1
 
 #if ENABLE_DEBUG_TRACE
@@ -188,8 +190,11 @@ void throwRuntimeErrorV(const char* msg, va_list ap)
 void throwRuntimeError(const char* msg, ...)
     __attribute__((__noreturn__, __format__(printf, 1, 2)));
 
+void mlock(folly::MicroLock*);
+
 struct SpinLock {
-  std::atomic<uintptr_t> m_bits;
+  std::atomic<uint8_t> m_bits;
+  void init();
   void lock();
   void unlock();
 };

--- a/src/runtime/native/src/memoize.cpp
+++ b/src/runtime/native/src/memoize.cpp
@@ -3666,7 +3666,8 @@ void Context::addDependency(Revision& lockedInput) {
       // No need for the 'lockify' overhead here.
       m_mutex.lock();
 
-      bool freshlyInserted = m_calls.emplace(&lockedInput, m_calls.size()).second;
+      bool freshlyInserted =
+          m_calls.emplace(&lockedInput, m_calls.size()).second;
       if (freshlyInserted) {
         lockedInput.incref();
       }

--- a/src/runtime/native/src/util.cpp
+++ b/src/runtime/native/src/util.cpp
@@ -235,7 +235,7 @@ void SpinLock::unlock() {
   uint8_t oldBits = m_bits;
   const uint8_t newBits = oldBits & ~1;
 
-  if(oldBits & 1 == 0) {
+  if (oldBits & 1 == 0) {
     fprintf(stderr, "Internal error: spinlock double unlock\n");
     exit(70);
   }
@@ -245,7 +245,10 @@ void SpinLock::unlock() {
           newBits,
           std::memory_order_release,
           std::memory_order_relaxed))) {
-    fprintf(stderr, "Internal error: spinlock in an impossible state %d\n", (int)m_bits.load() & 2 != 0);
+    fprintf(
+        stderr,
+        "Internal error: spinlock in an impossible state %d\n",
+        (int)m_bits.load() & 2 != 0);
     exit(70);
   }
 }

--- a/tests/runtime/native/include/skip/InternTable.h
+++ b/tests/runtime/native/include/skip/InternTable.h
@@ -11,10 +11,10 @@
 
 #include "SmallTaggedPtr.h"
 
+#include <atomic>
+
 #include <boost/functional/hash.hpp>
 #include <boost/noncopyable.hpp>
-
-#include <folly/MicroLock.h>
 
 namespace skip {
 

--- a/tests/runtime/native/include/skip/util.h
+++ b/tests/runtime/native/include/skip/util.h
@@ -9,6 +9,7 @@
 
 #include "fwd.h"
 
+#include <atomic>
 #include <cstdint>
 #include <type_traits>
 
@@ -16,6 +17,8 @@
 
 #include <folly/lang/Bits.h>
 #include <folly/Memory.h>
+
+#include <folly/MicroLock.h>
 
 // #define ENABLE_DEBUG_TRACE 1
 
@@ -186,4 +189,13 @@ void throwRuntimeErrorV(const char* msg, va_list ap)
 
 void throwRuntimeError(const char* msg, ...)
     __attribute__((__noreturn__, __format__(printf, 1, 2)));
+
+void mlock(folly::MicroLock*);
+
+struct SpinLock {
+  std::atomic<uint8_t> m_bits;
+  void init();
+  void lock();
+  void unlock();
+};
 } // namespace skip

--- a/tests/runtime/native/src/memoize.cpp
+++ b/tests/runtime/native/src/memoize.cpp
@@ -831,8 +831,8 @@ void Invocation::decref() {
   safeDecref(*asIObj());
 }
 
-folly::MicroLock& Invocation::mutex() const {
-  return m_mutex;
+skip::SpinLock& Invocation::mutex() const {
+  return reinterpret_cast<skip::SpinLock&>(m_mutex);
 }
 
 bool Invocation::inList_lck() const {
@@ -3662,12 +3662,19 @@ void Context::addDependency(Revision& lockedInput) {
   assertLocked(lockedInput);
 
   if (!lockedInput.isPure_lck()) {
-    // No need for the 'lockify' overhead here.
-    std::lock_guard<folly::MicroLock> lock{m_mutex};
+    try {
+      // No need for the 'lockify' overhead here.
+      m_mutex.lock();
 
-    bool freshlyInserted = m_calls.emplace(&lockedInput, m_calls.size()).second;
-    if (freshlyInserted) {
-      lockedInput.incref();
+      bool freshlyInserted =
+          m_calls.emplace(&lockedInput, m_calls.size()).second;
+      if (freshlyInserted) {
+        lockedInput.incref();
+      }
+      m_mutex.unlock();
+    } catch (const std::exception& ex) {
+      m_mutex.unlock();
+      throw(ex);
     }
   }
 }
@@ -3691,7 +3698,7 @@ std::vector<Revision::Ptr> Context::linearizeTrace() {
   return v;
 }
 
-folly::MicroLock& Context::mutex() const {
+SpinLock& Context::mutex() const {
   return m_mutex;
 }
 
@@ -3914,7 +3921,7 @@ Invocation::Ptr Cell::invocation() const {
   return m_invocation;
 }
 
-folly::MicroLock& Cell::mutex() const {
+SpinLock& Cell::mutex() const {
   return m_invocation->mutex();
 }
 


### PR DESCRIPTION
We used MicroLocks in a few places (not that many to be honest). The way a MicroLock works is that the two lower bits are used to encode the state of the lock. The lowest one 0x1 is used to say if someone holds the lock or not. The second bit 0x2 is used to say if someone is waiting on that lock, if that is the case, they should be awaken the moment the lock is released.

I would have replaced those locks with std::mutex, but the problem is that there are quite a few places in the runtime (cf, Invocation, Memoize etc ...) making assumptions about the layout of the lock, and expects sizes to be the same etc ...

So what I did instead is that I replaced the MicroLock with a SpinLock. The idea is relatively simple, you only use the lowest bit to say if the lock is held, and then spin while it is not available (with a little help to the scheduler, notifying that we are spinning).

I have not observed any difference in performance on the code of the compiler itself, except for one, the Invocation lock, that causes a small regression (which is not very surprising, an invocation can take time).

Ideally, we should revisit that at some point and replace the SpinLock with a real lock in the places where it matters. But I am going to leave this like that for now and revisit it later. The small regression (~< 5%) is acceptable ...