### PR TITLE
Remove folly headers

### DIFF
--- a/src/runtime/native/include/skip/Finalized.h
+++ b/src/runtime/native/include/skip/Finalized.h
@@ -13,7 +13,6 @@
 #include "Obstack.h"
 #include "objects.h"
 
-#include <folly/lang/SafeAssert.h>
 #include <boost/intrusive_ptr.hpp>
 
 namespace skip {

--- a/src/runtime/native/include/skip/InternTable.h
+++ b/src/runtime/native/include/skip/InternTable.h
@@ -21,7 +21,7 @@ namespace skip {
 /**
  * An IObj* plus some tag bits used by the InternTable.
  *
- * The low two bits are a folly::MicroLock, used to lock a Bucket.
+ * The low two bits are a skip::SpinLock, used to lock a Bucket.
  * They are only used in the head of the list, i.e. the pointer stored
  * directly in the buckets_ array.
  *
@@ -47,7 +47,7 @@ struct InternPtr final : SmallTaggedPtr<
                              2 // numAlignBits: interned pointers are only
                                // guaranteed aligned mod 4.
                              > {
-  /// The low two bits of each bucket are used as a folly::MicroLock.
+  /// The low two bits of each bucket are used as a skip::SpinLock.
   enum { kNumLockBits = 2 };
 
   enum { kNumExtraHashBits = kNumTagBits - kNumLockBits };
@@ -74,7 +74,7 @@ struct InternPtr final : SmallTaggedPtr<
  * This is a hash table used to intern Skip objects (IObj*).
  *
  * It uses an intrusive linked list of objects per bucket with per-bucket
- * locking via a folly::MicroLock.
+ * locking via a skip::SpinLock.
  *
  * Each pointer in the chain uses leftover "tag bits" to hold additional
  * bits of the hash of the pointed-to object. There is no need to even

--- a/src/runtime/native/include/skip/Process.h
+++ b/src/runtime/native/include/skip/Process.h
@@ -62,7 +62,7 @@ struct UnownedProcess {
 
 // A Process is analogous to an operating system process, containing
 // an "address space" (Obstack, in our case) and other "local" context.
-// Unlike a folly fiber, it does not retain an associated program stack.
+// It does not retain an associated program stack.
 //
 // Just as an OS process can be either suspended in the kernel or actively
 // run by some core, so can a Process be suspended or actively run by some

--- a/src/runtime/native/include/skip/Type.h
+++ b/src/runtime/native/include/skip/Type.h
@@ -20,7 +20,6 @@
 #include <boost/noncopyable.hpp>
 #include <boost/iterator/iterator_facade.hpp>
 
-#include <folly/lang/Bits.h>
 #include <folly/Likely.h>
 
 #include <atomic>

--- a/src/runtime/native/include/skip/config.h
+++ b/src/runtime/native/include/skip/config.h
@@ -11,13 +11,6 @@
 // we compile the preamble with very little config, so including
 // this stuff will break who-knows-what.
 
-// For FOLLY_SANITIZE_*
-#include <folly/CPortability.h>
-
-#if FOLLY_SANITIZE || FOLLY_SANITIZE_ADDRESS || FOLLY_SANITIZE_THREAD
-#define SKIP_SANITIZE 1
-#endif
-
 #if !SKIP_SANITIZE
 // For JEMALLOC_VERSION_*
 #include <algorithm>

--- a/tests/runtime/native/include/skip/Finalized.h
+++ b/tests/runtime/native/include/skip/Finalized.h
@@ -13,7 +13,6 @@
 #include "Obstack.h"
 #include "objects.h"
 
-#include <folly/lang/SafeAssert.h>
 #include <boost/intrusive_ptr.hpp>
 
 namespace skip {

--- a/tests/runtime/native/include/skip/InternTable.h
+++ b/tests/runtime/native/include/skip/InternTable.h
@@ -21,7 +21,7 @@ namespace skip {
 /**
  * An IObj* plus some tag bits used by the InternTable.
  *
- * The low two bits are a folly::MicroLock, used to lock a Bucket.
+ * The low two bits are a skip::SpinLock, used to lock a Bucket.
  * They are only used in the head of the list, i.e. the pointer stored
  * directly in the buckets_ array.
  *
@@ -47,7 +47,7 @@ struct InternPtr final : SmallTaggedPtr<
                              2 // numAlignBits: interned pointers are only
                                // guaranteed aligned mod 4.
                              > {
-  /// The low two bits of each bucket are used as a folly::MicroLock.
+  /// The low two bits of each bucket are used as a skip::SpinLock.
   enum { kNumLockBits = 2 };
 
   enum { kNumExtraHashBits = kNumTagBits - kNumLockBits };
@@ -74,7 +74,7 @@ struct InternPtr final : SmallTaggedPtr<
  * This is a hash table used to intern Skip objects (IObj*).
  *
  * It uses an intrusive linked list of objects per bucket with per-bucket
- * locking via a folly::MicroLock.
+ * locking via a skip::SpinLock.
  *
  * Each pointer in the chain uses leftover "tag bits" to hold additional
  * bits of the hash of the pointed-to object. There is no need to even

--- a/tests/runtime/native/include/skip/Process.h
+++ b/tests/runtime/native/include/skip/Process.h
@@ -62,7 +62,7 @@ struct UnownedProcess {
 
 // A Process is analogous to an operating system process, containing
 // an "address space" (Obstack, in our case) and other "local" context.
-// Unlike a folly fiber, it does not retain an associated program stack.
+// It does not retain an associated program stack.
 //
 // Just as an OS process can be either suspended in the kernel or actively
 // run by some core, so can a Process be suspended or actively run by some

--- a/tests/runtime/native/include/skip/Type.h
+++ b/tests/runtime/native/include/skip/Type.h
@@ -20,7 +20,6 @@
 #include <boost/noncopyable.hpp>
 #include <boost/iterator/iterator_facade.hpp>
 
-#include <folly/lang/Bits.h>
 #include <folly/Likely.h>
 
 #include <atomic>

--- a/tests/runtime/native/include/skip/config.h
+++ b/tests/runtime/native/include/skip/config.h
@@ -11,13 +11,6 @@
 // we compile the preamble with very little config, so including
 // this stuff will break who-knows-what.
 
-// For FOLLY_SANITIZE_*
-#include <folly/CPortability.h>
-
-#if FOLLY_SANITIZE || FOLLY_SANITIZE_ADDRESS || FOLLY_SANITIZE_THREAD
-#define SKIP_SANITIZE 1
-#endif
-
 #if !SKIP_SANITIZE
 // For JEMALLOC_VERSION_*
 #include <algorithm>


### PR DESCRIPTION
Just removed a bunch of now useless headers and updated a few comments to reflect the fact that we are no longer using folly.