### PR TITLE
feat(website): add DocSearch as recommended by docusaurus.

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -249,6 +249,10 @@ const siteConfig = {
     }
   },
   separateCss: ["specification/spec.css"],
+  algolia: {
+    apiKey: 'dfe1f25f0395cc6e7e74dd65fc4f8620',
+    indexName: 'skip',
+  },
   layouts: {
     'stdlib': require('./core/StdlibLayout.js')
   }


### PR DESCRIPTION
👋 team,

I am working on DocSearch. [We have an integration for Docusaurus](https://docusaurus.io/docs/en/search#enabling-the-search-bar). We thought it is a shame you can not also used this search that you can [find on reactjs for example](https://reactjs.org/).

This PR will add DocSearch to the documentation website. It will allow an user to have a learn-as-you-type experience by displaying results thanks to a dropdown in a live way.

Let me know if you need anything.