### PR TITLE
Disabling the logic zeroing gaps between fields in 32bits mode.

### DIFF
--- a/src/native/lower.sk
+++ b/src/native/lower.sk
@@ -579,7 +579,12 @@ mutable private class .Lower{
 
       // Zero any uninitialized bits preceding this field, or following in
       // the same 64-bit word.
-      while (nextGap.and(-64) <= last.and(-64)) {
+      // The math is wrong in 32-bits mode so disabling this for now.
+      while (
+        !isEmbedded32() &&
+        !targetIsWasm() &&
+        nextGap.and(-64) <= last.and(-64)
+      ) {
         _ = this.emitObstackInit{
           addrByteAlignment => 8,
           pos,


### PR DESCRIPTION
When initializing an object, the logic "zeros" the gaps between
the fields. I don't know why but I suspect it has to do with the
way interning works. The hash-consing of an object probably scans
the memory of the object at some point. The hash could give
different results if it included gaps with different values.

However, the interning in 32bits mode doesn't require this to
happen. So disabling it for now. It would probably be cleaner to
fix the math so that it also works in 32bits mode, but it's not
urgent.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated `docs/`
