### PR TITLE
Provide the right size for objects of 32bits in 32bits mode.

### DIFF
--- a/src/native/vtable.sk
+++ b/src/native/vtable.sk
@@ -488,7 +488,12 @@ private fun createGCType(sc: SClass, env: GlobalEnv): ConstantStruct {
     } else {
       // Figure out the object size.
       last = layout[layout.size() - 1];
-      roundUp(last.bitOffset + last.typ.bitSize, 64) / 8
+      size = last.bitOffset + last.typ.bitSize;
+      if ((targetIsWasm() || isEmbedded32()) && size == 32) {
+        4
+      } else {
+        roundUp(size, 64) / 8;
+      }
     };
 
     // We need this many words for our bit mask.


### PR DESCRIPTION
The value of the field m_userByteSize (in the type metadata) was
wrong for objects of size 32bits in 32bits mode.

It was rounding it up to 64bits, which is incorrect in 32bits mode.