### PR TITLE
Update README-cmake.md

### DIFF
--- a/docs/developer/README-cmake.md
+++ b/docs/developer/README-cmake.md
@@ -49,24 +49,6 @@ ln -s /usr/bin/python3 $SOME_DIR/python
 export PATH=$SOME_DIR:$PATH
 ```
 
-Disable warnings as errors by running `git apply` on the following patch
-
-```patch
-diff --git a/CMake/SkipCompiler.cmake b/CMake/SkipCompiler.cmake
-index c8ab080..f61d73c 100644
---- a/CMake/SkipCompiler.cmake
-+++ b/CMake/SkipCompiler.cmake
-@@ -52,7 +52,6 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR
-     $<$<CONFIG:Debug>:-g>
-     $<$<CONFIG:Release>:-DNDEBUG>
-     -Wall
--    -Werror
-     -msse4.2
-     -Wno-sign-compare
-     )
-
-```
-
 ### OS X
 
 Install Homebrew


### PR DESCRIPTION
Disable seemingly outdated instruction, `-Werror` is not present around https://github.com/skiplang/skip/blob/master/CMake/SkipCompiler.cmake#L54
