### PR TITLE
website: Fix broken Playground link in topnav

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -17,7 +17,7 @@ const siteConfig = {
     { doc: "tutorial", label: "Tutorial" },
     { doc: "hello_world", label: "Docs" },
     { doc: "string", label: "Stdlib" },
-    { href: "/playground/", label: "Playground" },
+    { href: "/playground", label: "Playground" },
     { blog: true, label: "Blog" },
     { href: "https://github.com/skiplang/skip", label: "GitHub" },
   ],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR removes a trailing slash for the Playground link in the website topnav. 

<!--- Describe your changes in detail -->

## Motivation and Context

That trailing slash was adding `index.html` to the url, causing the url to 404.

## How Has This Been Tested?

Tested this locally. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated `docs/`
